### PR TITLE
chore(#2): add TypeScript compiler and config

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,16 +15,20 @@
     "lint:md": "markdownlint-cli2 '**/*.md' '#node_modules'",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
+    "typecheck": "tsc --noEmit",
+    "build": "tsc",
     "prepare": "husky",
     "test": "vitest run"
   },
   "devDependencies": {
     "@commitlint/cli": "^20.4.2",
     "@commitlint/config-conventional": "^20.4.2",
+    "@types/node": "^25.3.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "markdownlint-cli2": "^0.21.0",
     "prettier": "^3.8.1",
+    "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   },
   "pnpm": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@commitlint/config-conventional':
         specifier: ^20.4.2
         version: 20.4.2
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.3.0
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -26,6 +29,9 @@ importers:
       prettier:
         specifier: ^3.8.1
         version: 3.8.1
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       vitest:
         specifier: ^4.0.18
         version: 4.0.18(@types/node@25.3.0)(jiti@2.6.1)(yaml@2.8.2)

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,1 @@
+export const rules: unknown[] = [];

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "outDir": "dist",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true
+  },
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts", "src/**/__tests__"]
+}


### PR DESCRIPTION
## Summary

- Add `typescript` and `@types/node` as devDependencies
- Create `tsconfig.json` with strict mode, ES2022 target, Node16 modules
- Add minimal `src/index.ts` placeholder (replaced in later step)
- Add `typecheck` and `build` scripts to `package.json`

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run build` creates `dist/` with no test files
- [x] `pnpm run format:check` passes
- [x] `pnpm run lint:md` passes
- [x] `pnpm test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)