### PR TITLE
chore(#34): add TSDoc documentation standards

### DIFF
--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -29,11 +29,14 @@ Implement the rule specified in `$ARGUMENTS`.
    cases from the spec as acceptance criteria
 4. Implement the rule at `src/rules/<rule-name>/index.ts`
    following the pattern in `docs/plan/01-architecture.md`
-5. Register the rule in `src/index.ts`
-6. Add the rule to `src/recommended.ts` with its default
+5. Add TSDoc comments to the rule's exported function,
+   `ruleName`, `messages`, and `meta` objects. Include
+   `@example` showing a BAD case that triggers the rule.
+6. Register the rule in `src/index.ts`
+7. Add the rule to `src/recommended.ts` with its default
    setting from the spec
-7. Run `pnpm check` — all tests must pass
-8. Commit:
+8. Run `pnpm check` — all tests must pass
+9. Commit:
 
    ```bash
    git add -A

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ pnpm run format:check
 - Conventional commits: `feat(#N):`, `fix(#N):`, `chore(#N):`, `docs(#N):` — always reference
   the issue number
 - Branch naming: `<type>/sass-lint-<issue#>-<title>` (e.g. `feat/sass-lint-12-no-debug`)
+- TSDoc on all exported functions and constants — include `@param`, `@returns`, `@example`
 
 ## Workflow Rules
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,6 +1,17 @@
 import eslint from '@eslint/js';
+import tsdoc from 'eslint-plugin-tsdoc';
 import tseslint from 'typescript-eslint';
 
-export default tseslint.config(eslint.configs.recommended, ...tseslint.configs.recommended, {
-  ignores: ['dist/', 'node_modules/', 'coverage/'],
-});
+export default tseslint.config(
+  eslint.configs.recommended,
+  ...tseslint.configs.recommended,
+  {
+    ignores: ['dist/', 'node_modules/', 'coverage/'],
+  },
+  {
+    files: ['**/*.ts'],
+    plugins: { tsdoc },
+    languageOptions: { parserOptions: { tsconfigRootDir: import.meta.dirname } },
+    rules: { 'tsdoc/syntax': 'warn' },
+  },
+);

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@eslint/js": "^10.0.1",
     "@types/node": "^25.3.0",
     "eslint": "^10.0.1",
+    "eslint-plugin-tsdoc": "^0.4.0",
     "husky": "^9.1.7",
     "lint-staged": "^16.2.7",
     "markdownlint-cli2": "^0.21.0",
@@ -38,7 +39,10 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "esbuild"
-    ]
+    ],
+    "patchedDependencies": {
+      "eslint-plugin-tsdoc@0.4.0": "patches/eslint-plugin-tsdoc@0.4.0.patch"
+    }
   },
   "packageManager": "pnpm@10.18.3"
 }

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,15 @@
+# Patches
+
+## `eslint-plugin-tsdoc@0.4.0`
+
+Fixes two ESLint 10 (flat config) incompatibilities:
+
+1. **`context.parserOptions` removed** — the plugin reads `tsconfigRootDir` from
+   `context.parserOptions`, which no longer exists in ESLint 10. The patch falls back to
+   `context.languageOptions.parserOptions`.
+
+2. **`context.getSourceCode()` removed** — replaced by `context.sourceCode`. The patch
+   uses `context.sourceCode` with a fallback to `context.getSourceCode()`.
+
+**Remove when**: `eslint-plugin-tsdoc` releases a version with native ESLint 10 support.
+Track [microsoft/tsdoc#389](https://github.com/microsoft/tsdoc/issues/389).

--- a/patches/eslint-plugin-tsdoc@0.4.0.patch
+++ b/patches/eslint-plugin-tsdoc@0.4.0.patch
@@ -1,0 +1,23 @@
+diff --git a/lib/index.js b/lib/index.js
+index 73c357f96e3c69ac87e19cc3e5d2733073d6aef3..ec6dfca91f7944bb4bd0e31d01451176623f56b5 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -29,7 +29,8 @@ const plugin = {
+                 const sourceFilePath = context.filename;
+                 // If eslint is configured with @typescript-eslint/parser, there is a parser option
+                 // to explicitly specify where the tsconfig file is. Use that if available.
+-                const tsConfigDir = context.parserOptions.tsconfigRootDir;
++                const parserOptions = context.parserOptions || (context.languageOptions && context.languageOptions.parserOptions) || {};
++                const tsConfigDir = parserOptions.tsconfigRootDir;
+                 Debug_1.Debug.log(`Linting: "${sourceFilePath}"`);
+                 const tsdocConfiguration = new tsdoc_1.TSDocConfiguration();
+                 try {
+@@ -68,7 +69,7 @@ const plugin = {
+                     });
+                 }
+                 const tsdocParser = new tsdoc_1.TSDocParser(tsdocConfiguration);
+-                const sourceCode = context.getSourceCode();
++                const sourceCode = context.sourceCode || context.getSourceCode();
+                 const checkCommentBlocks = function (node) {
+                     for (const comment of sourceCode.getAllComments()) {
+                         if (comment.type !== 'Block') {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  eslint-plugin-tsdoc@0.4.0:
+    hash: c60bb0ed05db937d569628e4d450a54a85bcda464cd698befe17dcf785b1a626
+    path: patches/eslint-plugin-tsdoc@0.4.0.patch
+
 importers:
 
   .:
@@ -23,6 +28,9 @@ importers:
       eslint:
         specifier: ^10.0.1
         version: 10.0.1(jiti@2.6.1)
+      eslint-plugin-tsdoc:
+        specifier: ^0.4.0
+        version: 0.4.0(patch_hash=c60bb0ed05db937d569628e4d450a54a85bcda464cd698befe17dcf785b1a626)
       husky:
         specifier: ^9.1.7
         version: 9.1.7
@@ -338,6 +346,12 @@ packages:
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
+  '@microsoft/tsdoc-config@0.17.1':
+    resolution: {integrity: sha512-UtjIFe0C6oYgTnad4q1QP4qXwLhe6tIpNTRStJ2RZEPIkqQPREAwE5spzVxsdn9UaEMUqhh0AqSx3X4nWAKXWw==}
+
+  '@microsoft/tsdoc@0.15.1':
+    resolution: {integrity: sha512-4aErSrCR/On/e5G2hDP0wjooqDdauzEbIq8hIkIe5pXV0rtWJZvdCEKL0ykZxex+IxIwBp0eGeV48hQN07dXtw==}
+
   '@nodelib/fs.scandir@2.1.5':
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -613,6 +627,9 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ajv@8.12.0:
+    resolution: {integrity: sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==}
+
   ajv@8.18.0:
     resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
@@ -815,6 +832,9 @@ packages:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
 
+  eslint-plugin-tsdoc@0.4.0:
+    resolution: {integrity: sha512-MT/8b4aKLdDClnS8mP3R/JNjg29i0Oyqd/0ym6NnQf+gfKbJJ4ZcSh2Bs1H0YiUMTBwww5JwXGTWot/RwyJ7aQ==}
+
   eslint-scope@9.1.1:
     resolution: {integrity: sha512-GaUN0sWim5qc8KVErfPBWmc31LEsOkrUJbvJZV+xuL3u2phMUK4HIvXlWAakfC8W4nzlK+chPEAkYOYb5ZScIw==}
     engines: {node: ^20.19.0 || ^22.13.0 || >=24}
@@ -919,6 +939,9 @@ packages:
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
 
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
@@ -947,6 +970,10 @@ packages:
   globby@16.1.0:
     resolution: {integrity: sha512-+A4Hq7m7Ze592k9gZRy4gJ27DrXRNnC1vPjxTt1qQxEY8RxagBkBxivkCwg7FxSTG0iLLEMaUx13oOr0R2/qcQ==}
     engines: {node: '>=20'}
+
+  hasown@2.0.2:
+    resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
 
   husky@9.1.7:
     resolution: {integrity: sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==}
@@ -984,6 +1011,10 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-core-module@2.16.1:
+    resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
+    engines: {node: '>= 0.4'}
 
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
@@ -1029,6 +1060,9 @@ packages:
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
+
+  jju@1.4.0:
+    resolution: {integrity: sha512-8wb9Yw966OSxApiCt0K3yNJL8pnNeIv+OEq2YMidz4FKP6nonSRoOXc80iXY4JaN2FC11B9qsNmDsm+ZOfMROA==}
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
@@ -1290,6 +1324,9 @@ packages:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
 
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
@@ -1348,6 +1385,11 @@ packages:
   resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
+
+  resolve@1.22.11:
+    resolution: {integrity: sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
 
   restore-cursor@5.1.0:
     resolution: {integrity: sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==}
@@ -1433,6 +1475,10 @@ packages:
   strip-ansi@7.1.2:
     resolution: {integrity: sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==}
     engines: {node: '>=12'}
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -1849,6 +1895,15 @@ snapshots:
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
+  '@microsoft/tsdoc-config@0.17.1':
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      ajv: 8.12.0
+      jju: 1.4.0
+      resolve: 1.22.11
+
+  '@microsoft/tsdoc@0.15.1': {}
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2110,6 +2165,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.12.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+      uri-js: 4.4.1
+
   ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
@@ -2300,6 +2362,11 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
+  eslint-plugin-tsdoc@0.4.0(patch_hash=c60bb0ed05db937d569628e4d450a54a85bcda464cd698befe17dcf785b1a626):
+    dependencies:
+      '@microsoft/tsdoc': 0.15.1
+      '@microsoft/tsdoc-config': 0.17.1
+
   eslint-scope@9.1.1:
     dependencies:
       '@types/esrecurse': 4.3.1
@@ -2421,6 +2488,8 @@ snapshots:
   fsevents@2.3.3:
     optional: true
 
+  function-bind@1.1.2: {}
+
   get-caller-file@2.0.5: {}
 
   get-east-asian-width@1.5.0: {}
@@ -2452,6 +2521,10 @@ snapshots:
       slash: 5.1.0
       unicorn-magic: 0.4.0
 
+  hasown@2.0.2:
+    dependencies:
+      function-bind: 1.1.2
+
   husky@9.1.7: {}
 
   ignore@5.3.2: {}
@@ -2477,6 +2550,10 @@ snapshots:
       is-decimal: 2.0.1
 
   is-arrayish@0.2.1: {}
+
+  is-core-module@2.16.1:
+    dependencies:
+      hasown: 2.0.2
 
   is-decimal@2.0.1: {}
 
@@ -2505,6 +2582,8 @@ snapshots:
   isexe@2.0.0: {}
 
   jiti@2.6.1: {}
+
+  jju@1.4.0: {}
 
   js-tokens@4.0.0: {}
 
@@ -2882,6 +2961,8 @@ snapshots:
 
   path-key@3.1.1: {}
 
+  path-parse@1.0.7: {}
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -2915,6 +2996,12 @@ snapshots:
   resolve-from@4.0.0: {}
 
   resolve-from@5.0.0: {}
+
+  resolve@1.22.11:
+    dependencies:
+      is-core-module: 2.16.1
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
 
   restore-cursor@5.1.0:
     dependencies:
@@ -3013,6 +3100,8 @@ snapshots:
   strip-ansi@7.1.2:
     dependencies:
       ansi-regex: 6.2.2
+
+  supports-preserve-symlinks-flag@1.0.0: {}
 
   tinybench@2.9.0: {}
 


### PR DESCRIPTION
## TSDoc Documentation Requirements and Linting

Added TSDoc documentation requirements and automated linting to ensure consistent API documentation across the codebase.

### Changes

- **ESLint Configuration**: Added `eslint-plugin-tsdoc` with TSDoc syntax validation
- **Package Dependencies**: Installed `eslint-plugin-tsdoc@0.4.0` with ESLint 10 compatibility patch
- **Documentation Standards**: Updated coding standards to require TSDoc comments on all exported functions and constants with `@param`, `@returns`, and `@example` tags
- **Rule Implementation Process**: Updated add-rule skill to include TSDoc documentation step with BAD case examples
- **Compatibility Patch**: Created patch for `eslint-plugin-tsdoc` to fix ESLint 10 flat config incompatibilities (`context.parserOptions` and `context.getSourceCode()` issues)

## Checklist

- [ ] Tests pass (`pnpm check`)
- [ ] Rule registered in `src/index.ts` and `src/recommended.ts`
- [ ] Spec exists in `docs/plan/rules/`
- [ ] Commit message references issue number