### PR TITLE
feat(#5): add sass/no-debug rule

### DIFF
--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -48,3 +48,6 @@
 // directives like @unknown-thing below.
 @unknown-thing
   color: red
+
+// sass/no-debug
+@debug "should not ship"

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -21,6 +21,7 @@ describe('plugin entry', () => {
 
 describe('recommended config', () => {
   const config = {
+    plugins: ['./src/index.ts'],
     rules: recommended.rules,
     customSyntax,
   };
@@ -50,6 +51,7 @@ describe('recommended config', () => {
         'no-descending-specificity',
         'max-nesting-depth',
         'at-rule-no-unknown',
+        'sass/no-debug',
       ]),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,8 @@
  * is listed in a configuration's `plugins` field.
  */
 import type stylelint from 'stylelint';
+import noDebug from './rules/no-debug/index.js';
 
-const rules: stylelint.Plugin[] = [];
+const rules: stylelint.Plugin[] = [noDebug];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -44,5 +44,8 @@ export default {
     // Removed in Stylelint 16 (use Prettier instead):
     // 'no-eol-whitespace': true,
     // 'no-missing-end-of-source-newline': true,
+
+    // Plugin rules
+    'sass/no-debug': true,
   },
 };

--- a/src/rules/no-debug/index.test.ts
+++ b/src/rules/no-debug/index.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/no-debug': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/no-debug', () => {
+  it('rejects @debug with string', async () => {
+    const result = await lint('$width: 100px\n@debug "width is #{$width}"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-debug');
+  });
+
+  it('rejects @debug with expression', async () => {
+    const result = await lint('$map: (a: 1, b: 2)\n@debug map-get($map, a)');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects @debug inside mixin', async () => {
+    const result = await lint(
+      '=responsive($bp)\n  @debug "breakpoint: #{$bp}"\n  @media (min-width: $bp)\n    @content',
+    );
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects @debug inside function', async () => {
+    const result = await lint('@function double($n)\n  @debug $n * 2\n  @return $n * 2');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects @debug nested inside rule', async () => {
+    const result = await lint('.component\n  @debug &\n  color: red');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('accepts code without @debug', async () => {
+    const result = await lint('$width: 100px\n\n.container\n  max-width: $width');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @warn (separate rule)', async () => {
+    const result = await lint(
+      '=deprecated-mixin\n  @warn "This mixin is deprecated"\n  display: block',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @error', async () => {
+    const result = await lint(
+      '@function require-positive($n)\n  @if $n < 0\n    @error "Expected positive number, got #{$n}"\n  @return $n',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/no-debug/index.ts
+++ b/src/rules/no-debug/index.ts
@@ -1,0 +1,65 @@
+/**
+ * Rule: `sass/no-debug`
+ *
+ * Disallow `@debug` statements. These are development helpers
+ * that should not ship to production.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule
+ * $width: 100px
+ * @debug "width is #{$width}"
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/no-debug';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/no-debug.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: 'Unexpected @debug statement',
+});
+
+/**
+ * Stylelint rule function for `sass/no-debug`.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback that walks at-rules
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    root.walkAtRules('debug', (node) => {
+      utils.report({
+        message: messages.rejected,
+        node,
+        result,
+        ruleName,
+      });
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Summary

Adds a new `sass/no-debug` rule that disallows `@debug` statements in Sass code. The rule helps prevent development debugging statements from shipping to production by flagging any usage of the `@debug` directive.

## Checklist

- [ ] Tests pass (`pnpm check`)
- [ ] Rule registered in `src/index.ts` and `src/recommended.ts`
- [ ] Spec exists in `docs/plan/rules/`
- [ ] Commit message references issue number