### PR TITLE
feat(#7): add sass/no-warn rule

### DIFF
--- a/docs/rules/no-warn.md
+++ b/docs/rules/no-warn.md
@@ -1,0 +1,41 @@
+# sass/no-warn
+
+Disallow `@warn` statements. Warnings clutter build output and may indicate incomplete migrations.
+
+**Default**: `true`
+**Fixable**: No
+
+## BAD
+
+```sass
+// runtime warnings clutter CI output
+@warn "Deprecated stylesheet loaded"
+```
+
+```sass
+=old-clearfix
+  // migration notice should be enforced by a lint rule, not @warn
+  @warn "Use modern clearfix instead"
+  overflow: hidden
+```
+
+```sass
+@function to-rem($px)
+  // deprecation warnings belong in documentation, not build output
+  @warn "to-rem() is deprecated, use math.div()"
+  @return $px / 16 * 1rem
+```
+
+## GOOD
+
+```sass
+=old-clearfix
+  // removed @warn — use stylelint to catch deprecated mixin usage instead
+  overflow: hidden
+```
+
+```sass
+@function to-rem($px)
+  // no runtime warning — deprecation documented in CHANGELOG
+  @return $px / 16 * 1rem
+```

--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -51,3 +51,6 @@
 
 // sass/no-debug
 @debug "should not ship"
+
+// sass/no-warn
+@warn "should not ship"

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -52,6 +52,7 @@ describe('recommended config', () => {
         'max-nesting-depth',
         'at-rule-no-unknown',
         'sass/no-debug',
+        'sass/no-warn',
       ]),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,8 @@
  */
 import type stylelint from 'stylelint';
 import noDebug from './rules/no-debug/index.js';
+import noWarn from './rules/no-warn/index.js';
 
-const rules: stylelint.Plugin[] = [noDebug];
+const rules: stylelint.Plugin[] = [noDebug, noWarn];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -47,5 +47,6 @@ export default {
 
     // Plugin rules
     'sass/no-debug': true,
+    'sass/no-warn': true,
   },
 };

--- a/src/rules/no-warn/index.test.ts
+++ b/src/rules/no-warn/index.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/no-warn': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/no-warn', () => {
+  it('rejects @warn at root level', async () => {
+    const result = await lint('@warn "Deprecated stylesheet loaded"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-warn');
+  });
+
+  it('rejects @warn inside mixin', async () => {
+    const result = await lint(
+      '=old-clearfix\n  @warn "Use modern clearfix instead"\n  overflow: hidden',
+    );
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects @warn inside function', async () => {
+    const result = await lint(
+      '@function to-rem($px)\n  @warn "to-rem() is deprecated, use math.div()"\n  @return $px / 16 * 1rem',
+    );
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects @warn inside conditional', async () => {
+    const result = await lint(
+      '=spacing($size)\n  @if $size == "small"\n    @warn "Use sm token instead of small"\n  padding: $size',
+    );
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('accepts code without @warn', async () => {
+    const result = await lint(
+      '=clearfix\n  &::after\n    content: ""\n    display: table\n    clear: both',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts mixin with @content', async () => {
+    const result = await lint('=responsive($bp)\n  @media (min-width: $bp)\n    @content');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/no-warn/index.ts
+++ b/src/rules/no-warn/index.ts
@@ -1,0 +1,64 @@
+/**
+ * Rule: `sass/no-warn`
+ *
+ * Disallow `@warn` statements. Warnings clutter build output
+ * and may indicate incomplete migrations.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule
+ * @warn "Deprecated stylesheet loaded"
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/no-warn';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/no-warn.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: 'Unexpected @warn statement',
+});
+
+/**
+ * Stylelint rule function for `sass/no-warn`.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback that walks at-rules
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    root.walkAtRules('warn', (node) => {
+      utils.report({
+        message: messages.rejected,
+        node,
+        result,
+        ruleName,
+      });
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Summary

Add `sass/no-warn` rule to disallow `@warn` statements in Sass code. The rule helps prevent warnings from cluttering build output and may indicate incomplete migrations. The rule is enabled by default in the recommended configuration.

## Checklist

- [ ] Tests pass (`pnpm check`)
- [ ] Rule registered in `src/index.ts` and `src/recommended.ts`
- [ ] Spec exists in `docs/plan/rules/`
- [ ] Commit message references issue number