### PR TITLE
feat(#11): add sass/no-import rule

### DIFF
--- a/docs/rules/no-import.md
+++ b/docs/rules/no-import.md
@@ -1,0 +1,52 @@
+# sass/no-import
+
+Disallow `@import`. The Sass team deprecated `@import` in Dart Sass 1.80
+in favor of `@use` and `@forward`. Using `@import` causes global namespace
+pollution and makes dependency tracking impossible.
+
+**Default**: `true`
+**Fixable**: No
+
+## BAD
+
+```sass
+// pollutes the global namespace
+@import "variables"
+```
+
+```sass
+// makes dependency tracking impossible
+@import "utils/mixins"
+```
+
+```sass
+// deprecated since Dart Sass 1.80
+@import "theme.sass"
+```
+
+```sass
+// URL imports are also flagged
+@import url("https://fonts.googleapis.com/css?family=Roboto")
+```
+
+## GOOD
+
+```sass
+// module-scoped access to variables
+@use "variables"
+```
+
+```sass
+// namespaced import avoids collisions
+@use "utils/mixins" as mx
+```
+
+```sass
+// re-export for downstream consumers
+@forward "theme"
+```
+
+```sass
+// configure module defaults at load time
+@use "config" with ($primary: #036, $border-radius: 4px)
+```

--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -54,3 +54,6 @@
 
 // sass/no-warn
 @warn "should not ship"
+
+// sass/no-import
+@import "should-use-use-instead"

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -53,6 +53,7 @@ describe('recommended config', () => {
         'at-rule-no-unknown',
         'sass/no-debug',
         'sass/no-warn',
+        'sass/no-import',
       ]),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,8 @@ import type stylelint from 'stylelint';
 import noDebug from './rules/no-debug/index.js';
 import noWarn from './rules/no-warn/index.js';
 
-const rules: stylelint.Plugin[] = [noDebug, noWarn];
+import noImport from './rules/no-import/index.js';
+
+const rules: stylelint.Plugin[] = [noDebug, noWarn, noImport];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -48,5 +48,6 @@ export default {
     // Plugin rules
     'sass/no-debug': true,
     'sass/no-warn': true,
+    'sass/no-import': true,
   },
 };

--- a/src/rules/no-import/index.test.ts
+++ b/src/rules/no-import/index.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/no-import': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/no-import', () => {
+  it('rejects single @import', async () => {
+    const result = await lint('@import "variables"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-import');
+  });
+
+  it('rejects @import with path', async () => {
+    const result = await lint('@import "utils/mixins"');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects @import with extension', async () => {
+    const result = await lint('@import "theme.sass"');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects multiple imports on separate lines', async () => {
+    const result = await lint('@import "variables"\n@import "mixins"\n@import "base"');
+    expect(result.warnings).toHaveLength(3);
+  });
+
+  it('rejects @import with media query', async () => {
+    const result = await lint('@import "print" screen');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects @import with url()', async () => {
+    const result = await lint('@import url("https://fonts.googleapis.com/css?family=Roboto")');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('accepts @use', async () => {
+    const result = await lint('@use "variables"');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @use with namespace', async () => {
+    const result = await lint('@use "utils/mixins" as mx');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @forward', async () => {
+    const result = await lint('@forward "theme"');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @use with configuration', async () => {
+    const result = await lint('@use "config" with ($primary: #036, $border-radius: 4px)');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts multiple @use statements', async () => {
+    const result = await lint('@use "sass:math"\n@use "sass:color"\n@use "variables" as vars');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/no-import/index.ts
+++ b/src/rules/no-import/index.ts
@@ -1,0 +1,52 @@
+/**
+ * Rule: `sass/no-import`
+ *
+ * Disallow `@import`. The Sass team deprecated `@import` in Dart Sass 1.80
+ * in favor of `@use` and `@forward`. Using `@import` causes global namespace
+ * pollution and makes dependency tracking impossible.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule
+ * @import "variables"
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/** Fully qualified rule name including the plugin namespace. */
+const ruleName = 'sass/no-import';
+
+/** Rule metadata for documentation linking. */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/no-import.md',
+};
+
+/** Diagnostic messages produced by this rule. */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: 'Unexpected @import. Use @use or @forward instead',
+});
+
+/**
+ * Stylelint rule function for `sass/no-import`.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback that walks at-rules
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, { actual: primary });
+    if (!validOptions) return;
+
+    root.walkAtRules('import', (node) => {
+      utils.report({ message: messages.rejected, node, result, ruleName });
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
<!-- markdownlint-disable MD041 -->

## Summary

Add `sass/no-import` rule to disallow deprecated `@import` statements in favor of `@use` and `@forward`. The rule flags all `@import` usage including URL imports, as `@import` causes global namespace pollution and makes dependency tracking impossible. The Sass team deprecated `@import` in Dart Sass 1.80.

## Checklist

- [ ] Tests pass (`pnpm check`)
- [ ] Rule registered in `src/index.ts` and `src/recommended.ts`
- [ ] Spec exists in `docs/plan/rules/`
- [ ] Commit message references issue number