### PR TITLE
feat(#6): add sass/dollar-variable-pattern rule

### DIFF
--- a/docs/rules/dollar-variable-pattern.md
+++ b/docs/rules/dollar-variable-pattern.md
@@ -1,0 +1,82 @@
+# sass/dollar-variable-pattern
+
+Enforce a naming pattern for `$variable` declarations. Default enforces `kebab-case`.
+
+**Default**: `/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/`
+**Fixable**: No
+
+## Options
+
+A regex pattern (string or RegExp) that variable names must match.
+
+## BAD
+
+```sass
+// camelCase
+$fontSize: 16px
+```
+
+```sass
+// PascalCase
+$FontSize: 16px
+```
+
+```sass
+// SCREAMING_CASE
+$FONT_SIZE: 16px
+```
+
+```sass
+// Double hyphens
+$font--size: 16px
+```
+
+```sass
+// Inside a rule
+.component
+  $myColor: blue
+  color: $myColor
+```
+
+## GOOD
+
+```sass
+// kebab-case
+$font-size: 16px
+$primary-color: #036
+$border-radius-sm: 4px
+```
+
+```sass
+// Single word
+$spacing: 8px
+```
+
+```sass
+// Variable with number
+$heading-2: 24px
+$z-index-100: 100
+```
+
+```sass
+// Inside a rule
+.component
+  $local-color: blue
+  color: $local-color
+```
+
+## Notes
+
+Sass treats `_` and `-` as interchangeable in identifiers. The parser normalizes all underscores to
+hyphens, so `$font_size` is seen as `$font-size`. Custom patterns should use `-`, not `_`.
+
+## Custom configuration
+
+Also allow `SCREAMING_SNAKE_CASE` for constants (the pattern uses `-` because Sass normalizes `_`
+to `-` in identifiers — see Notes above):
+
+```json
+{
+  "sass/dollar-variable-pattern": "/^[a-z][a-z0-9]*(-[a-z0-9]+)*$|^[A-Z][A-Z0-9]*(-[A-Z0-9]+)*$/"
+}
+```

--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -57,3 +57,6 @@
 
 // sass/no-import
 @import "should-use-use-instead"
+
+// sass/dollar-variable-pattern
+$fontSize: 16px

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,8 @@ import noDebug from './rules/no-debug/index.js';
 import noWarn from './rules/no-warn/index.js';
 
 import noImport from './rules/no-import/index.js';
+import dollarVariablePattern from './rules/dollar-variable-pattern/index.js';
 
-const rules: stylelint.Plugin[] = [noDebug, noWarn, noImport];
+const rules: stylelint.Plugin[] = [noDebug, noWarn, noImport, dollarVariablePattern];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -49,5 +49,6 @@ export default {
     'sass/no-debug': true,
     'sass/no-warn': true,
     'sass/no-import': true,
+    'sass/dollar-variable-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
   },
 };

--- a/src/rules/dollar-variable-pattern/index.test.ts
+++ b/src/rules/dollar-variable-pattern/index.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/dollar-variable-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/] },
+};
+
+async function lint(code: string, pattern?: RegExp | string) {
+  const overrides = pattern
+    ? { ...config, rules: { 'sass/dollar-variable-pattern': [pattern] } }
+    : config;
+  const result = await stylelint.lint({ code, config: overrides });
+  return result.results[0]!;
+}
+
+describe('sass/dollar-variable-pattern', () => {
+  // BAD cases from spec
+
+  it('rejects camelCase variable', async () => {
+    const result = await lint('$fontSize: 16px');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/dollar-variable-pattern');
+  });
+
+  // sass-parser normalizes _ to - in identifiers, so $font_size becomes
+  // $font-size which matches kebab-case. This is correct Sass behavior:
+  // underscores and hyphens are interchangeable in Sass identifiers.
+  it('treats snake_case as kebab-case (sass-parser normalizes _ to -)', async () => {
+    const result = await lint('$font_size: 16px');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('rejects PascalCase variable', async () => {
+    const result = await lint('$FontSize: 16px');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/dollar-variable-pattern');
+  });
+
+  it('rejects SCREAMING_CASE variable', async () => {
+    const result = await lint('$FONT_SIZE: 16px');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/dollar-variable-pattern');
+  });
+
+  // $1st-color is invalid Sass syntax — sass-parser throws a parse error.
+  // Variables cannot start with a digit in Sass, so this case is
+  // caught by the parser before our rule runs.
+  it('rejects variable starting with number (parse error)', async () => {
+    await expect(lint('$1st-color: red')).rejects.toThrow();
+  });
+
+  it('rejects double hyphens', async () => {
+    const result = await lint('$font--size: 16px');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects non-matching variable inside a rule', async () => {
+    const result = await lint('.component\n  $myColor: blue\n  color: $myColor');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  // GOOD cases from spec
+
+  it('accepts kebab-case variables', async () => {
+    const result = await lint('$font-size: 16px\n$primary-color: #036\n$border-radius-sm: 4px');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts single word variable', async () => {
+    const result = await lint('$spacing: 8px');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts variable with number', async () => {
+    const result = await lint('$heading-2: 24px\n$z-index-100: 100');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts matching variable inside a rule', async () => {
+    const result = await lint('.component\n  $local-color: blue\n  color: $local-color');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Custom pattern
+
+  // sass-parser normalizes _ to - so $FONT_SIZE becomes $FONT-SIZE;
+  // custom patterns must use - not _ to match screaming-case identifiers.
+  it('accepts SCREAMING-CASE with custom pattern', async () => {
+    const result = await lint(
+      '$FONT_SIZE: 16px',
+      /^[a-z][a-z0-9]*(-[a-z0-9]+)*$|^[A-Z][A-Z0-9]*(-[A-Z0-9]+)*$/,
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts string pattern option', async () => {
+    const result = await lint('$FONT_SIZE: 16px', '^[A-Z][A-Z0-9]*(-[A-Z0-9]+)*$');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('rejects when string pattern does not match', async () => {
+    const result = await lint('$font-size: 16px', '^[A-Z][A-Z0-9]*(-[A-Z0-9]+)*$');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  // Edge cases
+
+  it('does not flag variable references (only declarations)', async () => {
+    const result = await lint('.foo\n  color: $myColor');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('reports multiple violations', async () => {
+    const result = await lint('$fontSize: 16px\n$fontWeight: bold');
+    expect(result.warnings).toHaveLength(2);
+  });
+});

--- a/src/rules/dollar-variable-pattern/index.ts
+++ b/src/rules/dollar-variable-pattern/index.ts
@@ -1,0 +1,87 @@
+/**
+ * Rule: `sass/dollar-variable-pattern`
+ *
+ * Enforce a naming pattern for `$variable` declarations.
+ * Default enforces `kebab-case`.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule (camelCase)
+ * $fontSize: 16px
+ * ```
+ */
+import stylelint from 'stylelint';
+import { matchesPattern, toRegExp } from '../../utils/patterns.js';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/dollar-variable-pattern';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/dollar-variable-pattern.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ *
+ * @param name - The variable name that violated the pattern
+ * @param pattern - The expected pattern as a string
+ */
+const messages = utils.ruleMessages(ruleName, {
+  expected: (name: string, pattern: string) => `Expected $${name} to match pattern "${pattern}"`,
+});
+
+/** Default pattern: kebab-case */
+const DEFAULT_PATTERN = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+/**
+ * Stylelint rule function for `sass/dollar-variable-pattern`.
+ *
+ * Walks all declarations and checks those whose property starts with `$`
+ * against the configured pattern.
+ *
+ * @param primary - A regex pattern (string or RegExp) to match variable names against
+ * @returns A PostCSS plugin callback that walks declarations
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+      possible: [(v: unknown) => v instanceof RegExp || typeof v === 'string'],
+    });
+    if (!validOptions) return;
+
+    const pattern = primary ? toRegExp(primary) : DEFAULT_PATTERN;
+    if (!pattern) return;
+
+    root.walkDecls((decl) => {
+      const prop = decl.prop;
+
+      // Only check Sass variable declarations ($name)
+      if (!prop.startsWith('$')) return;
+
+      const name = prop.slice(1);
+
+      if (!matchesPattern(name, pattern)) {
+        utils.report({
+          message: messages.expected(name, pattern.toString()),
+          node: decl,
+          result,
+          ruleName,
+        });
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);

--- a/src/utils/patterns.ts
+++ b/src/utils/patterns.ts
@@ -1,0 +1,63 @@
+/**
+ * Shared naming pattern utilities for rules that enforce naming conventions
+ * via user-supplied regular expressions.
+ *
+ * Used by `sass/dollar-variable-pattern`, `sass/percent-placeholder-pattern`,
+ * `sass/at-mixin-pattern`, and `sass/at-function-pattern`.
+ */
+
+/**
+ * Convert a primary option (string or RegExp) to a `RegExp` instance.
+ *
+ * Accepts either a `RegExp` object or a string pattern (with or without
+ * surrounding slashes). Returns `null` if the input is invalid.
+ *
+ * Note: string patterns do not support regex flags (e.g. `"/pattern/i"`).
+ * Use a `RegExp` object directly when flags are needed.
+ *
+ * @param pattern - A regex string (e.g. `"^[a-z]+$"`) or `RegExp`
+ * @returns The compiled `RegExp`, or `null` if conversion fails
+ *
+ * @example
+ * ```ts
+ * toRegExp(/^[a-z]+$/);          // RegExp
+ * toRegExp('^[a-z]+$');          // RegExp
+ * toRegExp('/^[a-z]+$/');        // RegExp (strips slashes)
+ * ```
+ */
+export function toRegExp(pattern: string | RegExp): RegExp | null {
+  if (pattern instanceof RegExp) {
+    return pattern;
+  }
+
+  if (typeof pattern !== 'string') {
+    return null;
+  }
+
+  // Strip surrounding slashes if present: "/^foo$/" → "^foo$"
+  const stripped =
+    pattern.startsWith('/') && pattern.endsWith('/') ? pattern.slice(1, -1) : pattern;
+
+  try {
+    return new RegExp(stripped);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Test whether a name matches the given pattern.
+ *
+ * @param name - The identifier to test (without sigil like `$` or `%`)
+ * @param pattern - A `RegExp` to match against
+ * @returns `true` if the name matches, `false` otherwise
+ *
+ * @example
+ * ```ts
+ * matchesPattern('font-size', /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/); // true
+ * matchesPattern('fontSize', /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/);  // false
+ * ```
+ */
+export function matchesPattern(name: string, pattern: RegExp): boolean {
+  return pattern.test(name);
+}


### PR DESCRIPTION
## Summary

- Adds `sass/dollar-variable-pattern` rule — enforces naming conventions for `$variable` declarations (default: kebab-case)
- Introduces shared `src/utils/patterns.ts` utility (`toRegExp`, `matchesPattern`) for all Phase 2 naming pattern rules
- 16 tests covering BAD/GOOD spec cases, custom patterns (RegExp + string), edge cases

## Notes

sass-parser normalizes `_` to `-` in identifiers (Sass treats them as interchangeable). Tests and docs reflect this behavior — custom patterns should use `-`, not `_`.

## Test plan

- [x] `pnpm check` passes (typecheck + lint + format + test)
- [x] 43 tests pass (16 new + 27 existing)
- [x] PAL code review passed

Closes #6