### PR TITLE
feat(#13): add sass/at-mixin-pattern rule

### DIFF
--- a/docs/rules/at-mixin-pattern.md
+++ b/docs/rules/at-mixin-pattern.md
@@ -1,0 +1,74 @@
+# sass/at-mixin-pattern
+
+Enforce a naming pattern for mixin names in `@mixin` declarations. Default enforces `kebab-case`.
+
+**Default**: `/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/`
+**Fixable**: No
+
+## Options
+
+A regex pattern (string or RegExp) that mixin names must match.
+
+## BAD
+
+```sass
+// camelCase with = shorthand
+=flexCenter
+  display: flex
+```
+
+```sass
+// PascalCase with = shorthand
+=FlexCenter
+  display: flex
+```
+
+```sass
+// camelCase with @mixin syntax
+@mixin respondTo($bp)
+  @content
+```
+
+## GOOD
+
+```sass
+// kebab-case with = shorthand
+=flex-center
+  display: flex
+```
+
+```sass
+// kebab-case with @mixin syntax
+@mixin respond-to($bp)
+  @content
+```
+
+```sass
+// Single word
+=clearfix
+  display: block
+```
+
+```sass
+// With numbers
+=heading-2
+  font-weight: bold
+```
+
+## Notes
+
+Sass treats `_` and `-` as interchangeable in identifiers. The parser normalizes all underscores to
+hyphens, so `=flex_center` is seen as `=flex-center`. Custom patterns should use `-`, not `_`.
+
+The `=` shorthand for `@mixin` is normalized by sass-parser, so both syntaxes are checked by this
+rule.
+
+## Custom configuration
+
+Allow PascalCase mixin names (e.g. for component mixins):
+
+```json
+{
+  "sass/at-mixin-pattern": "/^[A-Z][a-zA-Z0-9]*$/"
+}
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,14 @@ import noWarn from './rules/no-warn/index.js';
 
 import noImport from './rules/no-import/index.js';
 import dollarVariablePattern from './rules/dollar-variable-pattern/index.js';
+import atMixinPattern from './rules/at-mixin-pattern/index.js';
 
-const rules: stylelint.Plugin[] = [noDebug, noWarn, noImport, dollarVariablePattern];
+const rules: stylelint.Plugin[] = [
+  noDebug,
+  noWarn,
+  noImport,
+  dollarVariablePattern,
+  atMixinPattern,
+];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -50,5 +50,6 @@ export default {
     'sass/no-warn': true,
     'sass/no-import': true,
     'sass/dollar-variable-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
+    'sass/at-mixin-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
   },
 };

--- a/src/rules/at-mixin-pattern/index.test.ts
+++ b/src/rules/at-mixin-pattern/index.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/at-mixin-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/] },
+};
+
+async function lint(code: string, pattern?: RegExp | string) {
+  const overrides = pattern ? { ...config, rules: { 'sass/at-mixin-pattern': [pattern] } } : config;
+  const result = await stylelint.lint({ code, config: overrides });
+  return result.results[0]!;
+}
+
+describe('sass/at-mixin-pattern', () => {
+  // BAD cases from spec
+
+  it('rejects camelCase mixin with = shorthand', async () => {
+    const result = await lint('=flexCenter\n  display: flex');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-mixin-pattern');
+  });
+
+  // sass-parser normalizes _ to - in identifiers, so flex_center becomes
+  // flex-center which matches kebab-case. This is correct Sass behavior:
+  // underscores and hyphens are interchangeable in Sass identifiers.
+  it('treats snake_case as kebab-case (sass-parser normalizes _ to -)', async () => {
+    const result = await lint('=flex_center\n  display: flex');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('rejects PascalCase mixin with = shorthand', async () => {
+    const result = await lint('=FlexCenter\n  display: flex');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-mixin-pattern');
+  });
+
+  it('rejects camelCase mixin with @mixin syntax', async () => {
+    const result = await lint('@mixin respondTo($bp)\n  @content');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-mixin-pattern');
+  });
+
+  // GOOD cases from spec
+
+  it('accepts kebab-case mixin with = shorthand', async () => {
+    const result = await lint('=flex-center\n  display: flex');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts kebab-case mixin with @mixin syntax', async () => {
+    const result = await lint('@mixin respond-to($bp)\n  @content');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts single word mixin', async () => {
+    const result = await lint('=clearfix\n  display: block');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts mixin name with numbers', async () => {
+    const result = await lint('=heading-2\n  font-weight: bold');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Custom pattern
+
+  it('accepts PascalCase with custom pattern', async () => {
+    const result = await lint('=FlexCenter\n  display: flex', /^[A-Z][a-zA-Z0-9]*$/);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts string pattern option', async () => {
+    const result = await lint('=FlexCenter\n  display: flex', '^[A-Z][a-zA-Z0-9]*$');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('rejects when string pattern does not match', async () => {
+    const result = await lint('=flex-center\n  display: flex', '^[A-Z][a-zA-Z0-9]*$');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  // Edge cases
+
+  it('does not flag @include calls (only declarations)', async () => {
+    const result = await lint('.foo\n  +flexCenter');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('reports multiple violations', async () => {
+    const result = await lint('=flexCenter\n  display: flex\n=alignItems\n  align-items: center');
+    expect(result.warnings).toHaveLength(2);
+  });
+
+  it('extracts name correctly when params have parentheses', async () => {
+    const result = await lint('@mixin respondTo($breakpoint, $type: screen)\n  @content');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('accepts valid mixin with complex params', async () => {
+    const result = await lint('@mixin respond-to($breakpoint, $type: screen)\n  @content');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/at-mixin-pattern/index.ts
+++ b/src/rules/at-mixin-pattern/index.ts
@@ -1,0 +1,117 @@
+/**
+ * Rule: `sass/at-mixin-pattern`
+ *
+ * Enforce a naming pattern for `@mixin` declarations.
+ * Default enforces `kebab-case`.
+ *
+ * sass-parser normalizes the `=` shorthand to `@mixin`, so both
+ * `=flex-center` and `@mixin flex-center` are caught by
+ * `walkAtRules('mixin')`.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule (camelCase)
+ * =flexCenter
+ *   display: flex
+ * ```
+ */
+import stylelint from 'stylelint';
+import { matchesPattern, toRegExp } from '../../utils/patterns.js';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/at-mixin-pattern';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/at-mixin-pattern.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ *
+ * @param name - The mixin name that violated the pattern
+ * @param pattern - The expected pattern as a string
+ */
+const messages = utils.ruleMessages(ruleName, {
+  expected: (name: string, pattern: string) =>
+    `Expected mixin "${name}" to match pattern "${pattern}"`,
+});
+
+/** Default pattern: kebab-case */
+const DEFAULT_PATTERN = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+/**
+ * Extract the mixin name from an at-rule's params string.
+ *
+ * The params string may contain the mixin name followed by parenthesized
+ * arguments (e.g. `"respond-to($bp)"`) or just the name (e.g. `"clearfix"`).
+ *
+ * @param params - The raw `atRule.params` value
+ * @returns The mixin name (first word before `(` or whitespace)
+ *
+ * @example
+ * ```ts
+ * extractMixinName('respond-to($bp)');   // 'respond-to'
+ * extractMixinName('clearfix');          // 'clearfix'
+ * ```
+ */
+function extractMixinName(params: string): string {
+  const trimmed = params.trim();
+  const parenIndex = trimmed.indexOf('(');
+  const spaceIndex = trimmed.indexOf(' ');
+
+  let endIndex = trimmed.length;
+  if (parenIndex !== -1) endIndex = parenIndex;
+  if (spaceIndex !== -1 && spaceIndex < endIndex) endIndex = spaceIndex;
+
+  return trimmed.slice(0, endIndex);
+}
+
+/**
+ * Stylelint rule function for `sass/at-mixin-pattern`.
+ *
+ * Walks all `@mixin` at-rules (which also covers `=` shorthand thanks to
+ * sass-parser normalization) and checks the mixin name against the
+ * configured pattern.
+ *
+ * @param primary - A regex pattern (string or RegExp) to match mixin names
+ * @returns A PostCSS plugin callback that walks at-rules
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+      possible: [(v: unknown) => v instanceof RegExp || typeof v === 'string'],
+    });
+    if (!validOptions) return;
+
+    const pattern = primary ? toRegExp(primary) : DEFAULT_PATTERN;
+    if (!pattern) return;
+
+    root.walkAtRules('mixin', (atRule) => {
+      const name = extractMixinName(atRule.params);
+      if (!name) return;
+
+      if (!matchesPattern(name, pattern)) {
+        utils.report({
+          message: messages.expected(name, pattern.toString()),
+          node: atRule,
+          result,
+          ruleName,
+        });
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Add `sass/at-mixin-pattern` rule for enforcing mixin naming conventions

- Add `sass/at-mixin-pattern` rule that enforces a naming pattern for Sass mixins
- Walks `@mixin` at-rules and validates the name against a configurable regex (default: `kebab-case`)
- Supports both `@mixin` syntax and `=` shorthand (normalized by sass-parser)
- Handles parameter extraction from mixin declarations with complex signatures
- Includes comprehensive test coverage with 15 test cases covering valid/invalid patterns
- User-facing documentation at `docs/rules/at-mixin-pattern.md`
- Rule registered in plugin exports and recommended configuration

## Test plan

- [x] `pnpm check` passes
- [x] BAD cases: camelCase, PascalCase mixins trigger violations
- [x] GOOD cases: kebab-case names, single words, numbers pass validation
- [x] Custom pattern support via string or RegExp configuration
- [x] Edge cases: complex parameters, multiple violations, include calls ignored