### PR TITLE
Closes #8: add sass/at-extend-no-missing-placeholder rule

### DIFF
--- a/docs/rules/at-extend-no-missing-placeholder.md
+++ b/docs/rules/at-extend-no-missing-placeholder.md
@@ -1,0 +1,173 @@
+# sass/at-extend-no-missing-placeholder
+
+Disallow `@extend` with non-placeholder selectors.
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+Sass `@extend` lets one selector inherit the styles of another without duplicating declarations.
+However, _what_ you extend matters:
+
+- **Extending a class, element, or ID** (e.g. `@extend .btn`) rewrites every rule that mentions
+  `.btn` anywhere in the stylesheet to also include the extending selector. The compiled CSS can
+  grow with selectors you never wrote and never intended, especially in large codebases or when
+  extending selectors from third-party libraries.
+
+- **Extending a `%placeholder`** (e.g. `@extend %btn-base`) avoids this problem entirely.
+  Placeholders are invisible in the compiled CSS on their own — they only produce output when
+  extended, so the result is exactly the selectors you expect and nothing more.
+
+```sass
+// Extending a class — every rule that mentions .btn
+// gets an extra .primary-btn selector in compiled CSS
+.btn
+  padding: 8px 16px
+  border: 1px solid gray
+
+.sidebar .btn
+  font-size: 14px
+
+.primary-btn
+  @extend .btn
+  background: blue
+```
+
+Compiled CSS:
+
+```css
+/* .primary-btn appears everywhere .btn was used */
+.btn,
+.primary-btn {
+  padding: 8px 16px;
+  border: 1px solid gray;
+}
+
+.sidebar .btn,
+.sidebar .primary-btn {
+  font-size: 14px;
+}
+
+.primary-btn {
+  background: blue;
+}
+```
+
+Using a placeholder keeps output predictable:
+
+```sass
+%btn-base
+  padding: 8px 16px
+  border: 1px solid gray
+
+.btn
+  @extend %btn-base
+
+.primary-btn
+  @extend %btn-base
+  background: blue
+```
+
+Compiled CSS:
+
+```css
+/* only the selectors you wrote */
+.btn,
+.primary-btn {
+  padding: 8px 16px;
+  border: 1px solid gray;
+}
+
+.primary-btn {
+  background: blue;
+}
+```
+
+This rule enforces that every `@extend` targets a `%placeholder` selector.
+
+## Configuration
+
+```json
+{
+  "sass/at-extend-no-missing-placeholder": true
+}
+```
+
+## BAD
+
+```sass
+// Extending a class
+.error
+  color: red
+
+.alert
+  @extend .error
+```
+
+```sass
+// Extending an element
+.nav-item
+  @extend a
+```
+
+```sass
+// Extending an ID
+.widget
+  @extend #main
+```
+
+```sass
+// Extending a compound selector
+.btn-primary
+  @extend .btn.large
+```
+
+```sass
+// Extending a class inside a nested rule
+.card
+  .header
+    @extend .title
+```
+
+## GOOD
+
+```sass
+// Extending a placeholder
+%visually-hidden
+  position: absolute
+  width: 1px
+  height: 1px
+  clip: rect(0 0 0 0)
+  overflow: hidden
+
+.sr-only
+  @extend %visually-hidden
+```
+
+```sass
+// Multiple placeholder extends
+%reset-list
+  margin: 0
+  padding: 0
+  list-style: none
+
+%inline-items
+  display: flex
+
+.nav
+  @extend %reset-list
+  @extend %inline-items
+```
+
+```sass
+// Placeholder extend inside nested rule
+%text-truncate
+  overflow: hidden
+  text-overflow: ellipsis
+  white-space: nowrap
+
+.card
+  .title
+    @extend %text-truncate
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ import dollarVariablePattern from './rules/dollar-variable-pattern/index.js';
 import atMixinPattern from './rules/at-mixin-pattern/index.js';
 import percentPlaceholderPattern from './rules/percent-placeholder-pattern/index.js';
 import atFunctionPattern from './rules/at-function-pattern/index.js';
+import atExtendNoMissingPlaceholder from './rules/at-extend-no-missing-placeholder/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -22,6 +23,7 @@ const rules: stylelint.Plugin[] = [
   atMixinPattern,
   percentPlaceholderPattern,
   atFunctionPattern,
+  atExtendNoMissingPlaceholder,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -53,5 +53,6 @@ export default {
     'sass/at-mixin-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
     'sass/percent-placeholder-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
     'sass/at-function-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
+    'sass/at-extend-no-missing-placeholder': true,
   },
 };

--- a/src/rules/at-extend-no-missing-placeholder/index.test.ts
+++ b/src/rules/at-extend-no-missing-placeholder/index.test.ts
@@ -1,0 +1,100 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/at-extend-no-missing-placeholder': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/at-extend-no-missing-placeholder', () => {
+  // BAD cases — extending non-placeholder selectors
+  it('rejects extending a class', async () => {
+    const result = await lint('.error\n  color: red\n\n.alert\n  @extend .error');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-extend-no-missing-placeholder');
+  });
+
+  it('rejects extending an element', async () => {
+    const result = await lint('.nav-item\n  @extend a');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects extending an ID', async () => {
+    const result = await lint('.widget\n  @extend #main');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects extending a compound selector', async () => {
+    const result = await lint('.btn-primary\n  @extend .btn.large');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects extending a class inside a nested rule', async () => {
+    const result = await lint('.card\n  .header\n    @extend .title');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects a selector list with a non-placeholder', async () => {
+    const result = await lint('.nav\n  @extend %reset-list, .some-class');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects extending an attribute selector', async () => {
+    const result = await lint('.item\n  @extend [data-foo]');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects extending a pseudo-class or pseudo-element', async () => {
+    const result = await lint('.button\n  @extend :hover\n.text\n  @extend ::before');
+    expect(result.warnings).toHaveLength(2);
+  });
+
+  it('rejects extending a class with !optional flag', async () => {
+    const result = await lint('.alert\n  @extend .error !optional');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  // GOOD cases — extending placeholders
+  it('accepts extending a placeholder', async () => {
+    const result = await lint(
+      '%visually-hidden\n  position: absolute\n  width: 1px\n\n.sr-only\n  @extend %visually-hidden',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts multiple placeholder extends', async () => {
+    const result = await lint(
+      '%reset-list\n  margin: 0\n\n%inline-items\n  display: flex\n\n.nav\n  @extend %reset-list\n  @extend %inline-items',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts placeholder extend inside nested rule', async () => {
+    const result = await lint(
+      '%text-truncate\n  overflow: hidden\n\n.card\n  .title\n    @extend %text-truncate',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts a selector list with only placeholders', async () => {
+    const result = await lint('.nav\n  @extend %reset-list, %inline-items');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts extending a placeholder with !optional flag', async () => {
+    const result = await lint('.sr-only\n  @extend %visually-hidden !optional');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/at-extend-no-missing-placeholder/index.ts
+++ b/src/rules/at-extend-no-missing-placeholder/index.ts
@@ -1,0 +1,84 @@
+/**
+ * Rule: `sass/at-extend-no-missing-placeholder`
+ *
+ * Disallow `@extend` with non-placeholder selectors. Extending classes,
+ * elements, or IDs leads to unexpected selector bloat in compiled CSS.
+ * Use `%placeholder` selectors instead.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule
+ * .alert
+ *   @extend .error
+ *
+ * // GOOD — placeholder selector
+ * .sr-only
+ *   @extend %visually-hidden
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/at-extend-no-missing-placeholder';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/at-extend-no-missing-placeholder.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: 'Expected a placeholder selector (e.g. %placeholder) to follow @extend',
+});
+
+/**
+ * Stylelint rule function for `sass/at-extend-no-missing-placeholder`.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback that walks `@extend` at-rules
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    root.walkAtRules('extend', (node) => {
+      let params = node.params.trim();
+
+      // Strip !optional flag before checking selectors
+      if (params.endsWith('!optional')) {
+        params = params.slice(0, -'!optional'.length).trim();
+      }
+
+      const selectors = params.split(',').map((s) => s.trim());
+
+      for (const selector of selectors) {
+        if (selector && !selector.startsWith('%')) {
+          utils.report({
+            message: messages.rejected,
+            node,
+            result,
+            ruleName,
+          });
+          return;
+        }
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Description

- Add `sass/at-extend-no-missing-placeholder` rule that disallows `@extend` with non-placeholder selectors
- Handles edge cases: selector lists (`@extend %foo, .bar`) and `!optional` flag  
- 12 tests (7 BAD, 5 GOOD) covering classes, elements, IDs, compound selectors, nesting, selector lists, and `!optional`
- User-facing docs at `docs/rules/at-extend-no-missing-placeholder.md`

## Test plan

- [x] BAD cases: class, element, ID, compound selector, nested rule, selector list with non-placeholder, class with `!optional`
- [x] GOOD cases: placeholder, multiple placeholders, nested placeholder, placeholder selector list, placeholder with `!optional`
- [x] Rule registered in `src/index.ts` and `src/recommended.ts`