### PR TITLE
feat(#9): add sass/percent-placeholder-pattern rule

### DIFF
--- a/docs/rules/percent-placeholder-pattern.md
+++ b/docs/rules/percent-placeholder-pattern.md
@@ -1,0 +1,86 @@
+# sass/percent-placeholder-pattern
+
+`%name` defines a placeholder selector — a rule block that only exists to be `@extend`ed. It never
+outputs CSS on its own:
+
+```sass
+// Define a placeholder
+%visually-hidden
+  position: absolute
+  width: 1px
+  height: 1px
+  overflow: hidden
+
+// Use it via @extend
+.sr-only
+  @extend %visually-hidden
+```
+
+The key benefit over extending a regular class (like `@extend .visually-hidden`) is that
+`%visually-hidden` doesn't appear in the output CSS unless something extends it — no unused CSS
+bloat.
+
+This rule enforces a naming pattern for `%placeholder` selectors. Default enforces `kebab-case`.
+
+**Default**: `/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/`
+**Fixable**: No
+
+## Options
+
+A regex pattern (string or RegExp) that placeholder names must match.
+
+## BAD
+
+```sass
+// camelCase
+%visuallyHidden
+  display: none
+```
+
+```sass
+// PascalCase
+%VisuallyHidden
+  display: none
+```
+
+```sass
+// Starts with uppercase
+%Hidden
+  display: none
+```
+
+## GOOD
+
+```sass
+// kebab-case
+%visually-hidden
+  display: none
+```
+
+```sass
+// Single word
+%clearfix
+  overflow: hidden
+```
+
+```sass
+// Multiple words
+%reset-list
+  margin: 0
+```
+
+## Notes
+
+Unlike `$variable` declarations, sass-parser does **not** normalize `_` to `-` in placeholder
+selectors. `%visually_hidden` keeps the underscore and will fail the default kebab-case pattern.
+Use `-` in placeholder names for consistency.
+
+## Custom configuration
+
+Allow `PascalCase` placeholders:
+
+```json
+{
+  "sass/percent-placeholder-pattern": "/^[A-Z][a-zA-Z0-9]*$/"
+}
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import noWarn from './rules/no-warn/index.js';
 import noImport from './rules/no-import/index.js';
 import dollarVariablePattern from './rules/dollar-variable-pattern/index.js';
 import atMixinPattern from './rules/at-mixin-pattern/index.js';
+import percentPlaceholderPattern from './rules/percent-placeholder-pattern/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -18,6 +19,7 @@ const rules: stylelint.Plugin[] = [
   noImport,
   dollarVariablePattern,
   atMixinPattern,
+  percentPlaceholderPattern,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -51,5 +51,6 @@ export default {
     'sass/no-import': true,
     'sass/dollar-variable-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
     'sass/at-mixin-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
+    'sass/percent-placeholder-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
   },
 };

--- a/src/rules/percent-placeholder-pattern/index.test.ts
+++ b/src/rules/percent-placeholder-pattern/index.test.ts
@@ -1,0 +1,123 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: {
+    'sass/percent-placeholder-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
+  },
+};
+
+async function lint(code: string, pattern?: RegExp | string) {
+  const overrides = pattern
+    ? {
+        ...config,
+        rules: { 'sass/percent-placeholder-pattern': [pattern] },
+      }
+    : config;
+  const result = await stylelint.lint({ code, config: overrides });
+  return result.results[0]!;
+}
+
+describe('sass/percent-placeholder-pattern', () => {
+  // BAD cases from spec
+
+  it('rejects camelCase placeholder', async () => {
+    const result = await lint('%visuallyHidden\n  display: none');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/percent-placeholder-pattern');
+  });
+
+  // Unlike $variables, sass-parser does NOT normalize _ to - in
+  // placeholder selectors, so %visually_hidden keeps the underscore
+  // and fails the default kebab-case pattern.
+  it('rejects snake_case placeholder (no normalization in selectors)', async () => {
+    const result = await lint('%visually_hidden\n  display: none');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/percent-placeholder-pattern');
+  });
+
+  it('rejects PascalCase placeholder', async () => {
+    const result = await lint('%VisuallyHidden\n  display: none');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/percent-placeholder-pattern');
+  });
+
+  it('rejects placeholder starting with uppercase', async () => {
+    const result = await lint('%Hidden\n  display: none');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/percent-placeholder-pattern');
+  });
+
+  // GOOD cases from spec
+
+  it('accepts kebab-case placeholder', async () => {
+    const result = await lint('%visually-hidden\n  display: none');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts single word placeholder', async () => {
+    const result = await lint('%clearfix\n  overflow: hidden');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts multi-word kebab-case placeholder', async () => {
+    const result = await lint('%reset-list\n  margin: 0');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts placeholder name with numbers', async () => {
+    const result = await lint('%grid-12-col\n  width: 100%');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Custom pattern
+
+  it('accepts PascalCase with custom pattern', async () => {
+    const result = await lint('%VisuallyHidden\n  display: none', /^[A-Z][a-zA-Z0-9]*$/);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts string pattern option', async () => {
+    const result = await lint('%VisuallyHidden\n  display: none', '^[A-Z][a-zA-Z0-9]*$');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('rejects when string pattern does not match', async () => {
+    const result = await lint('%visually-hidden\n  display: none', '^[A-Z][a-zA-Z0-9]*$');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  // Edge cases
+
+  it('does not flag non-placeholder selectors', async () => {
+    const result = await lint('.myComponent\n  color: red');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('reports multiple violations', async () => {
+    const code = '%visuallyHidden\n  display: none\n' + '%VisuallyHidden\n  display: none';
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(2);
+  });
+
+  it('checks placeholder inside @extend usage (no flag)', async () => {
+    const result = await lint('.foo\n  @extend %visuallyHidden');
+    // @extend references should not be flagged — only
+    // placeholder definitions should trigger the rule
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('does not crash on invalid regex string', async () => {
+    // toRegExp returns null for invalid patterns; rule exits early
+    const result = await lint('%foo\n  display: none', '[');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/percent-placeholder-pattern/index.ts
+++ b/src/rules/percent-placeholder-pattern/index.ts
@@ -1,0 +1,89 @@
+/**
+ * Rule: `sass/percent-placeholder-pattern`
+ *
+ * Enforce a naming pattern for `%placeholder` selectors.
+ * Default enforces `kebab-case`.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule (camelCase)
+ * %visuallyHidden
+ *   display: none
+ * ```
+ */
+import stylelint from 'stylelint';
+import { matchesPattern, toRegExp } from '../../utils/patterns.js';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/percent-placeholder-pattern';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/percent-placeholder-pattern.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ *
+ * @param name - The placeholder name that violated the pattern
+ * @param pattern - The expected pattern as a string
+ */
+const messages = utils.ruleMessages(ruleName, {
+  expected: (name: string, pattern: string) => `Expected %${name} to match pattern "${pattern}"`,
+});
+
+/** Default pattern: kebab-case */
+const DEFAULT_PATTERN = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+/**
+ * Stylelint rule function for `sass/percent-placeholder-pattern`.
+ *
+ * Walks all rules and checks those whose selector starts with `%`
+ * against the configured pattern.
+ *
+ * @param primary - A regex pattern (string or RegExp) to match
+ *   placeholder names against
+ * @returns A PostCSS plugin callback that walks rules
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+      possible: [(v: unknown) => v instanceof RegExp || typeof v === 'string'],
+    });
+    if (!validOptions) return;
+
+    const pattern = primary ? toRegExp(primary) : DEFAULT_PATTERN;
+    if (!pattern) return;
+
+    root.walkRules((rule) => {
+      const selector = rule.selector;
+
+      // Only check placeholder selectors (%name)
+      if (!selector.startsWith('%')) return;
+
+      const name = selector.slice(1);
+
+      if (!matchesPattern(name, pattern)) {
+        utils.report({
+          message: messages.expected(name, pattern.toString()),
+          node: rule,
+          result,
+          ruleName,
+        });
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Description

- Add `sass/percent-placeholder-pattern` rule that enforces a naming pattern for `%placeholder` selectors
- Walks rules starting with `%` and validates the name against a configurable regex (default: `kebab-case`)
- Supports custom patterns via primary option
- 15 tests covering BAD/GOOD cases and custom pattern configuration
- User-facing docs at `docs/rules/percent-placeholder-pattern.md`

## Test plan

- [x] `pnpm check` passes
- [x] BAD cases: camelCase, PascalCase, snake_case, mixed naming
- [x] GOOD cases: kebab-case names, custom pattern matching
- [x] Rule registered in `src/index.ts` and `src/recommended.ts`