### PR TITLE
feat(#17): add sass/at-function-pattern rule

### DIFF
--- a/docs/rules/at-function-pattern.md
+++ b/docs/rules/at-function-pattern.md
@@ -1,0 +1,78 @@
+# sass/at-function-pattern
+
+`@function` defines a reusable computation that takes arguments and returns a value via `@return`.
+Unlike mixins (which output CSS), functions produce values you can use in any expression — property
+values, variable assignments, other function calls, etc.
+
+```sass
+@function to-rem($px)
+  @return math.div($px, 16) * 1rem
+
+body
+  font-size: to-rem(18)  // 1.125rem
+```
+
+This rule enforces a naming pattern for `@function` names. Default enforces `kebab-case`.
+
+**Default**: `/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/`
+**Fixable**: No
+
+## Options
+
+A regex pattern (string or RegExp) that function names must match.
+
+## BAD
+
+```sass
+// camelCase
+@function toRem($px)
+  @return math.div($px, 16) * 1rem
+```
+
+```sass
+// PascalCase
+@function ToRem($px)
+  @return math.div($px, 16) * 1rem
+```
+
+```sass
+// Leading underscore (normalized to -)
+@function _private-helper($val)
+  @return $val * 2
+```
+
+## GOOD
+
+```sass
+// kebab-case
+@function to-rem($px)
+  @return math.div($px, 16) * 1rem
+```
+
+```sass
+// Single word
+@function spacing($multiplier)
+  @return $multiplier * 8px
+```
+
+```sass
+// Multi-word with hyphens
+@function z-index-above($layer)
+  @return $layer + 1
+```
+
+## Notes
+
+Sass treats `_` and `-` as interchangeable in identifiers. The parser normalizes all underscores to
+hyphens, so `@function to_rem` is seen as `@function to-rem`. Custom patterns should use `-`, not
+`_`.
+
+## Custom configuration
+
+Allow `camelCase` function names:
+
+```json
+{
+  "sass/at-function-pattern": "/^[a-zA-Z][a-zA-Z0-9]*$/"
+}
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import noImport from './rules/no-import/index.js';
 import dollarVariablePattern from './rules/dollar-variable-pattern/index.js';
 import atMixinPattern from './rules/at-mixin-pattern/index.js';
 import percentPlaceholderPattern from './rules/percent-placeholder-pattern/index.js';
+import atFunctionPattern from './rules/at-function-pattern/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -20,6 +21,7 @@ const rules: stylelint.Plugin[] = [
   dollarVariablePattern,
   atMixinPattern,
   percentPlaceholderPattern,
+  atFunctionPattern,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -52,5 +52,6 @@ export default {
     'sass/dollar-variable-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
     'sass/at-mixin-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
     'sass/percent-placeholder-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
+    'sass/at-function-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
   },
 };

--- a/src/rules/at-function-pattern/index.test.ts
+++ b/src/rules/at-function-pattern/index.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/at-function-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/] },
+};
+
+async function lint(code: string, pattern?: RegExp | string) {
+  const overrides = pattern
+    ? { ...config, rules: { 'sass/at-function-pattern': [pattern] } }
+    : config;
+  const result = await stylelint.lint({ code, config: overrides });
+  return result.results[0]!;
+}
+
+describe('sass/at-function-pattern', () => {
+  // BAD cases from spec
+
+  it('rejects camelCase function name', async () => {
+    const result = await lint('@function toRem($px)\n  @return $px / 16 * 1rem');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-function-pattern');
+  });
+
+  // sass-parser normalizes _ to - in identifiers, so to_rem becomes
+  // to-rem which matches kebab-case. This is correct Sass behavior:
+  // underscores and hyphens are interchangeable in Sass identifiers.
+  it('treats snake_case as kebab-case (sass-parser normalizes _ to -)', async () => {
+    const result = await lint('@function to_rem($px)\n  @return $px / 16 * 1rem');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('rejects PascalCase function name', async () => {
+    const result = await lint('@function ToRem($px)\n  @return $px / 16 * 1rem');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-function-pattern');
+  });
+
+  // sass-parser normalizes leading _ to -, so _private-helper becomes
+  // -private-helper which does not match kebab-case (starts with -).
+  it('rejects function starting with underscore (normalized to -)', async () => {
+    const result = await lint('@function _private-helper($val)\n  @return $val * 2');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-function-pattern');
+  });
+
+  // GOOD cases from spec
+
+  it('accepts kebab-case function name', async () => {
+    const result = await lint('@function to-rem($px)\n  @return $px / 16 * 1rem');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts single word function name', async () => {
+    const result = await lint('@function spacing($multiplier)\n  @return $multiplier * 8px');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts multi-word kebab-case', async () => {
+    const result = await lint('@function z-index-above($layer)\n  @return $layer + 1');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts kebab-case name with digits', async () => {
+    const result = await lint('@function grid-column-12()\n  @return 12');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Custom pattern
+
+  it('accepts camelCase with custom pattern', async () => {
+    const result = await lint(
+      '@function toRem($px)\n  @return $px / 16 * 1rem',
+      /^[a-zA-Z][a-zA-Z0-9]*$/,
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts string pattern option', async () => {
+    const result = await lint(
+      '@function toRem($px)\n  @return $px / 16 * 1rem',
+      '^[a-zA-Z][a-zA-Z0-9]*$',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('rejects when string pattern does not match', async () => {
+    const result = await lint(
+      '@function to-rem($px)\n  @return $px / 16 * 1rem',
+      '^[a-zA-Z][a-zA-Z0-9]*$',
+    );
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  // Edge cases
+
+  it('reports multiple violations', async () => {
+    const code = [
+      '@function toRem($px)',
+      '  @return $px / 16 * 1rem',
+      '@function ToEm($px)',
+      '  @return $px / 16 * 1em',
+    ].join('\n');
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(2);
+  });
+
+  it('does not flag non-function at-rules', async () => {
+    const result = await lint('@use "colors"');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('handles function with no arguments', async () => {
+    const result = await lint('@function get-base-size()\n  @return 16px');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/at-function-pattern/index.ts
+++ b/src/rules/at-function-pattern/index.ts
@@ -1,0 +1,106 @@
+/**
+ * Rule: `sass/at-function-pattern`
+ *
+ * Enforce a naming pattern for `@function` names.
+ * Default enforces `kebab-case`.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule (camelCase)
+ * @function toRem($px)
+ *   @return $px / 16 * 1rem
+ * ```
+ */
+import stylelint from 'stylelint';
+import { matchesPattern, toRegExp } from '../../utils/patterns.js';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/at-function-pattern';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/at-function-pattern.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ *
+ * @param name - The function name that violated the pattern
+ * @param pattern - The expected pattern as a string
+ */
+const messages = utils.ruleMessages(ruleName, {
+  expected: (name: string, pattern: string) =>
+    `Expected @function "${name}" to match pattern "${pattern}"`,
+});
+
+/** Default pattern: kebab-case */
+const DEFAULT_PATTERN = /^[a-z][a-z0-9]*(-[a-z0-9]+)*$/;
+
+/**
+ * Extract the function name from `atRule.params`.
+ *
+ * The params string contains the function name followed by optional
+ * parenthesised arguments, e.g. `"to-rem($px)"` or `"get-base-size"`.
+ *
+ * @param params - The raw `params` string from the `@function` at-rule
+ * @returns The function name (first word before `(` or whitespace)
+ *
+ * @example
+ * ```ts
+ * extractFunctionName('to-rem($px)'); // 'to-rem'
+ * extractFunctionName('spacing($m)'); // 'spacing'
+ * ```
+ */
+function extractFunctionName(params: string): string {
+  const trimmed = params.trim();
+  const match = trimmed.match(/^([^\s(]+)/);
+  return match ? match[1]! : trimmed;
+}
+
+/**
+ * Stylelint rule function for `sass/at-function-pattern`.
+ *
+ * Walks all `@function` at-rules and checks their names against
+ * the configured pattern.
+ *
+ * @param primary - A regex pattern (string or RegExp) to match
+ *   function names against
+ * @returns A PostCSS plugin callback that walks at-rules
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+      possible: [(v: unknown) => v instanceof RegExp || typeof v === 'string'],
+    });
+    if (!validOptions) return;
+
+    const pattern = primary ? toRegExp(primary) : DEFAULT_PATTERN;
+    if (!pattern) return;
+
+    root.walkAtRules('function', (atRule) => {
+      const name = extractFunctionName(atRule.params);
+
+      if (!matchesPattern(name, pattern)) {
+        utils.report({
+          message: messages.expected(name, pattern.toString()),
+          node: atRule,
+          result,
+          ruleName,
+        });
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Add sass/at-function-pattern rule for enforcing function naming patterns

- Add `sass/at-function-pattern` rule that enforces a naming pattern for Sass `@function` declarations
- Validates function names against a configurable regex pattern (defaults to kebab-case: `/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/`)
- Extracts function names from `@function` at-rule params, handling both parameterized and parameterless functions
- Supports custom patterns via RegExp or string options
- Includes comprehensive test coverage with 14 test cases covering valid/invalid naming patterns and custom configurations
- Adds rule documentation at `docs/rules/at-function-pattern.md` with examples and configuration options
- Registers rule in main plugin exports and recommended configuration

## Test plan

- [x] Rule correctly rejects camelCase, PascalCase, and underscore-prefixed function names
- [x] Rule accepts kebab-case, single-word, and multi-word hyphenated function names  
- [x] Custom pattern support works with both RegExp and string inputs
- [x] Multiple violations reported in single file
- [x] Non-function at-rules ignored appropriately