### PR TITLE
Closes #15: add sass/no-global-function-names rule

### DIFF
--- a/docs/rules/no-global-function-names.md
+++ b/docs/rules/no-global-function-names.md
@@ -1,0 +1,149 @@
+<!-- markdownlint-disable MD024 -->
+
+# sass/no-global-function-names
+
+Disallow use of global Sass function names that have been moved to built-in modules.
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+Sass historically provided dozens of built-in functions — `darken()`, `map-get()`, `str-length()`,
+etc. — available globally without any import. Since Dart Sass 1.80, `@import` is deprecated and
+these functions have been reorganized into namespaced modules (`sass:color`, `sass:map`,
+`sass:math`, etc.) accessed via `@use`.
+
+The global names still work but are deprecated. Using them creates two problems:
+
+- **Migration debt** — global functions will eventually be removed, so code using them will break in
+  a future Sass release.
+- **Ambiguity** — some global names overlap with CSS-native functions. For example, both Sass and
+  CSS define `min()` and `max()`. The namespaced `math.min()` makes it unambiguous that you intend
+  the Sass version.
+
+```sass
+// Global — deprecated
+.btn
+  background: darken($primary, 10%)
+  color: mix($white, $primary, 80%)
+
+$keys: map-get($theme, colors)
+```
+
+```sass
+// Namespaced — recommended
+@use "sass:color"
+@use "sass:map"
+
+.btn
+  background: color.adjust($primary, $lightness: -10%)
+  color: color.mix($white, $primary, $weight: 80%)
+
+$keys: map.get($theme, colors)
+```
+
+This rule flags calls to deprecated global Sass functions and recommends their namespaced
+replacements. CSS-native functions like `min()`, `max()`, `round()`, `invert()`, and `grayscale()`
+are intentionally excluded to prevent false positives on valid CSS.
+
+## Configuration
+
+```json
+{
+  "sass/no-global-function-names": true
+}
+```
+
+## BAD
+
+```sass
+// Global adjust-color — should use color.adjust()
+.link
+  color: adjust-color($primary, $lightness: -10%)
+```
+
+```sass
+// Global darken — should use color.adjust()
+.btn
+  background: darken($primary, 10%)
+```
+
+```sass
+// Global lighten — should use color.adjust()
+.surface
+  background: lighten($gray, 20%)
+```
+
+```sass
+// Global mix — should use color.mix()
+.blend
+  color: mix($black, $primary, 50%)
+```
+
+```sass
+// Global map-get — should use map.get()
+.theme
+  color: map-get($colors, primary)
+```
+
+```sass
+// Global str-index — should use string.index()
+$pos: str-index("helvetica", "vet")
+```
+
+```sass
+// Global unitless — should use math.is-unitless()
+@function to-rem($val)
+  @if unitless($val)
+    @return $val * 1px
+  @return $val
+```
+
+```sass
+// Global percentage — should use math.percentage()
+.col-half
+  width: percentage(0.5)
+```
+
+## GOOD
+
+```sass
+// Namespaced color functions
+@use "sass:color"
+
+.link
+  color: color.adjust($primary, $lightness: -10%)
+```
+
+```sass
+// Namespaced math functions
+@use "sass:math"
+
+@function to-rem($px)
+  @return math.div($px, 16) * 1rem
+```
+
+```sass
+// Namespaced map functions
+@use "sass:map"
+
+.theme
+  color: map.get($colors, primary)
+```
+
+```sass
+// Namespaced list functions
+@use "sass:list"
+
+$first: list.nth($items, 1)
+```
+
+```sass
+// User-defined global functions are fine
+@function spacing($multiplier)
+  @return $multiplier * 8px
+
+.box
+  padding: spacing(2)
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import atFunctionPattern from './rules/at-function-pattern/index.js';
 import atExtendNoMissingPlaceholder from './rules/at-extend-no-missing-placeholder/index.js';
 import extendsBeforeDeclarations from './rules/extends-before-declarations/index.js';
 import mixinsBeforeDeclarations from './rules/mixins-before-declarations/index.js';
+import noGlobalFunctionNames from './rules/no-global-function-names/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -28,6 +29,7 @@ const rules: stylelint.Plugin[] = [
   atExtendNoMissingPlaceholder,
   extendsBeforeDeclarations,
   mixinsBeforeDeclarations,
+  noGlobalFunctionNames,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -56,5 +56,6 @@ export default {
     'sass/at-extend-no-missing-placeholder': true,
     'sass/extends-before-declarations': true,
     'sass/mixins-before-declarations': true,
+    'sass/no-global-function-names': true,
   },
 };

--- a/src/rules/no-global-function-names/index.test.ts
+++ b/src/rules/no-global-function-names/index.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/no-global-function-names': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/no-global-function-names', () => {
+  // --- BAD: global function names that should be namespaced ---
+
+  it('rejects adjust-color()', async () => {
+    const result = await lint('.link\n  color: adjust-color($primary, $lightness: -10%)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-global-function-names');
+    expect(result.warnings[0].text).toContain('adjust-color');
+    expect(result.warnings[0].text).toContain('color.adjust');
+  });
+
+  it('rejects darken()', async () => {
+    const result = await lint('.btn\n  background: darken($primary, 10%)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('darken');
+    expect(result.warnings[0].text).toContain('color.adjust');
+  });
+
+  it('rejects lighten()', async () => {
+    const result = await lint('.surface\n  background: lighten($gray, 20%)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('lighten');
+    expect(result.warnings[0].text).toContain('color.adjust');
+  });
+
+  it('rejects mix()', async () => {
+    const result = await lint('.blend\n  color: mix($black, $primary, 50%)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('mix');
+    expect(result.warnings[0].text).toContain('color.mix');
+  });
+
+  it('rejects map-get()', async () => {
+    const result = await lint('.theme\n  color: map-get($colors, primary)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('map-get');
+    expect(result.warnings[0].text).toContain('map.get');
+  });
+
+  it('rejects str-index() in a variable declaration', async () => {
+    const result = await lint('$pos: str-index("helvetica", "vet")');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('str-index');
+    expect(result.warnings[0].text).toContain('string.index');
+  });
+
+  it('rejects unitless() inside @if condition', async () => {
+    const code = [
+      '@function to-rem($val)',
+      '  @if unitless($val)',
+      '    @return $val * 1px',
+      '  @return $val',
+    ].join('\n');
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('unitless');
+    expect(result.warnings[0].text).toContain('math.is-unitless');
+  });
+
+  it('rejects percentage()', async () => {
+    const result = await lint('.col-half\n  width: percentage(0.5)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('percentage');
+    expect(result.warnings[0].text).toContain('math.percentage');
+  });
+
+  // --- Additional deprecated globals ---
+
+  it('rejects map-merge()', async () => {
+    const result = await lint('$merged: map-merge($a, $b)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('map-merge');
+    expect(result.warnings[0].text).toContain('map.merge');
+  });
+
+  it('rejects map-remove()', async () => {
+    const result = await lint('$clean: map-remove($map, key)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('map-remove');
+    expect(result.warnings[0].text).toContain('map.remove');
+  });
+
+  it('rejects map-has-key()', async () => {
+    const result = await lint('$has: map-has-key($map, key)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('map-has-key');
+    expect(result.warnings[0].text).toContain('map.has-key');
+  });
+
+  it('rejects map-keys()', async () => {
+    const result = await lint('$keys: map-keys($map)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('map-keys');
+    expect(result.warnings[0].text).toContain('map.keys');
+  });
+
+  it('rejects map-values()', async () => {
+    const result = await lint('$vals: map-values($map)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('map-values');
+    expect(result.warnings[0].text).toContain('map.values');
+  });
+
+  it('rejects str-length()', async () => {
+    const result = await lint('$len: str-length("hello")');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('str-length');
+    expect(result.warnings[0].text).toContain('string.length');
+  });
+
+  it('rejects comparable()', async () => {
+    const result = await lint('$ok: comparable(1px, 1em)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('comparable');
+    expect(result.warnings[0].text).toContain('math.compatible');
+  });
+
+  it('rejects multiple deprecated calls in one declaration', async () => {
+    const result = await lint('.x\n  color: mix(darken($a, 10%), $b, 50%)');
+    expect(result.warnings).toHaveLength(2);
+  });
+
+  // --- GOOD: namespaced and user-defined functions ---
+
+  it('accepts namespaced color.adjust()', async () => {
+    const code = '@use "sass:color"\n\n.link\n  color: color.adjust($primary, $lightness: -10%)';
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts namespaced math.div()', async () => {
+    const code = [
+      '@use "sass:math"',
+      '',
+      '@function to-rem($px)',
+      '  @return math.div($px, 16) * 1rem',
+    ].join('\n');
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts namespaced map.get()', async () => {
+    const code = '@use "sass:map"\n\n.theme\n  color: map.get($colors, primary)';
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts namespaced list.nth()', async () => {
+    const code = '@use "sass:list"\n\n$first: list.nth($items, 1)';
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts user-defined global function', async () => {
+    const code = [
+      '@function spacing($multiplier)',
+      '  @return $multiplier * 8px',
+      '',
+      '.box',
+      '  padding: spacing(2)',
+    ].join('\n');
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts function name as substring in non-function context', async () => {
+    const result = await lint('.darken\n  color: red');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // --- CSS-native functions excluded to prevent false positives ---
+
+  it('accepts CSS min()', async () => {
+    const result = await lint('.container\n  width: min(100px, 50vw)');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts CSS max()', async () => {
+    const result = await lint('.container\n  height: max(200px, 10vh)');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts CSS round()', async () => {
+    const result = await lint('.grid\n  width: round(100.5px)');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts CSS abs()', async () => {
+    const result = await lint('.offset\n  margin-left: abs(-10px)');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts CSS filter invert()', async () => {
+    const result = await lint('img\n  filter: invert(1)');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts CSS filter grayscale()', async () => {
+    const result = await lint('img\n  filter: grayscale(100%)');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts CSS filter saturate()', async () => {
+    const result = await lint('img\n  backdrop-filter: saturate(140%)');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts CSS alpha()', async () => {
+    const result = await lint('.el\n  color: alpha(red)');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts CSS opacity()', async () => {
+    const result = await lint('.el\n  filter: opacity(50%)');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/no-global-function-names/index.ts
+++ b/src/rules/no-global-function-names/index.ts
@@ -1,0 +1,246 @@
+/**
+ * Rule: `sass/no-global-function-names`
+ *
+ * Disallow use of global Sass function names that have been moved to
+ * built-in modules. Since Dart Sass 1.80, `@import` is deprecated and
+ * functions should be accessed via `@use "sass:*"` namespaced modules.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule
+ * .btn
+ *   background: darken($primary, 10%)
+ * ```
+ *
+ * @example
+ * ```sass
+ * // GOOD — namespaced
+ * @use "sass:color"
+ *
+ * .btn
+ *   background: color.adjust($primary, $lightness: -10%)
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/** Fully qualified rule name including the plugin namespace. */
+const ruleName = 'sass/no-global-function-names';
+
+/** Rule metadata for documentation linking. */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/no-global-function-names.md',
+};
+
+/**
+ * Entry in the deprecated function lookup table.
+ *
+ * @example
+ * ```ts
+ * { module: 'color', replacement: 'color.adjust' }
+ * ```
+ */
+interface DeprecatedFunction {
+  /** The `sass:*` module the function belongs to. */
+  module: string;
+  /** The recommended namespaced replacement (e.g. `color.adjust`). */
+  replacement: string;
+}
+
+/**
+ * Comprehensive map of deprecated global Sass function names to their
+ * namespaced replacements. Covers functions from sass:color, sass:list,
+ * sass:map, sass:math, sass:meta, sass:selector, and sass:string
+ * built-in modules.
+ *
+ * Functions that conflict with native CSS functions are intentionally
+ * excluded to prevent false positives (e.g. `min`, `max`, `round`,
+ * `abs`, `invert`, `grayscale`, `saturate`, `alpha`, `opacity`).
+ * See: https://github.com/stylelint-scss/stylelint-scss/issues/486
+ */
+const DEPRECATED_FUNCTIONS: ReadonlyMap<string, DeprecatedFunction> = new Map([
+  // sass:color
+  // Excluded: alpha, grayscale, invert, opacity, saturate (CSS-native)
+  ['adjust-color', { module: 'color', replacement: 'color.adjust' }],
+  ['adjust-hue', { module: 'color', replacement: 'color.adjust' }],
+  ['blue', { module: 'color', replacement: 'color.blue' }],
+  ['change-color', { module: 'color', replacement: 'color.change' }],
+  ['complement', { module: 'color', replacement: 'color.complement' }],
+  ['darken', { module: 'color', replacement: 'color.adjust' }],
+  ['desaturate', { module: 'color', replacement: 'color.adjust' }],
+  ['green', { module: 'color', replacement: 'color.green' }],
+  ['hue', { module: 'color', replacement: 'color.hue' }],
+  ['ie-hex-str', { module: 'color', replacement: 'color.ie-hex-str' }],
+  ['lighten', { module: 'color', replacement: 'color.adjust' }],
+  ['lightness', { module: 'color', replacement: 'color.lightness' }],
+  ['mix', { module: 'color', replacement: 'color.mix' }],
+  ['opacify', { module: 'color', replacement: 'color.adjust' }],
+  ['red', { module: 'color', replacement: 'color.red' }],
+  ['saturation', { module: 'color', replacement: 'color.saturation' }],
+  ['scale-color', { module: 'color', replacement: 'color.scale' }],
+  ['transparentize', { module: 'color', replacement: 'color.adjust' }],
+  ['fade-in', { module: 'color', replacement: 'color.adjust' }],
+  ['fade-out', { module: 'color', replacement: 'color.adjust' }],
+
+  // sass:list
+  ['append', { module: 'list', replacement: 'list.append' }],
+  ['index', { module: 'list', replacement: 'list.index' }],
+  ['is-bracketed', { module: 'list', replacement: 'list.is-bracketed' }],
+  ['join', { module: 'list', replacement: 'list.join' }],
+  ['length', { module: 'list', replacement: 'list.length' }],
+  ['list-separator', { module: 'list', replacement: 'list.separator' }],
+  ['nth', { module: 'list', replacement: 'list.nth' }],
+  ['set-nth', { module: 'list', replacement: 'list.set-nth' }],
+  ['zip', { module: 'list', replacement: 'list.zip' }],
+
+  // sass:map
+  ['map-get', { module: 'map', replacement: 'map.get' }],
+  ['map-has-key', { module: 'map', replacement: 'map.has-key' }],
+  ['map-keys', { module: 'map', replacement: 'map.keys' }],
+  ['map-merge', { module: 'map', replacement: 'map.merge' }],
+  ['map-remove', { module: 'map', replacement: 'map.remove' }],
+  ['map-values', { module: 'map', replacement: 'map.values' }],
+
+  // sass:math
+  // Excluded: abs, max, min, round (CSS Values Level 4 native)
+  ['ceil', { module: 'math', replacement: 'math.ceil' }],
+  ['comparable', { module: 'math', replacement: 'math.compatible' }],
+  ['floor', { module: 'math', replacement: 'math.floor' }],
+  ['percentage', { module: 'math', replacement: 'math.percentage' }],
+  ['random', { module: 'math', replacement: 'math.random' }],
+  ['unit', { module: 'math', replacement: 'math.unit' }],
+  ['unitless', { module: 'math', replacement: 'math.is-unitless' }],
+
+  // sass:meta
+  ['call', { module: 'meta', replacement: 'meta.call' }],
+  ['content-exists', { module: 'meta', replacement: 'meta.content-exists' }],
+  ['feature-exists', { module: 'meta', replacement: 'meta.feature-exists' }],
+  ['function-exists', { module: 'meta', replacement: 'meta.function-exists' }],
+  ['get-function', { module: 'meta', replacement: 'meta.get-function' }],
+  ['global-variable-exists', { module: 'meta', replacement: 'meta.global-variable-exists' }],
+  ['inspect', { module: 'meta', replacement: 'meta.inspect' }],
+  ['mixin-exists', { module: 'meta', replacement: 'meta.mixin-exists' }],
+  ['type-of', { module: 'meta', replacement: 'meta.type-of' }],
+  ['variable-exists', { module: 'meta', replacement: 'meta.variable-exists' }],
+
+  // sass:selector
+  ['is-superselector', { module: 'selector', replacement: 'selector.is-superselector' }],
+  ['selector-append', { module: 'selector', replacement: 'selector.append' }],
+  ['selector-extend', { module: 'selector', replacement: 'selector.extend' }],
+  ['selector-nest', { module: 'selector', replacement: 'selector.nest' }],
+  ['selector-parse', { module: 'selector', replacement: 'selector.parse' }],
+  ['selector-replace', { module: 'selector', replacement: 'selector.replace' }],
+  ['selector-unify', { module: 'selector', replacement: 'selector.unify' }],
+  ['simple-selectors', { module: 'selector', replacement: 'selector.simple-selectors' }],
+
+  // sass:string
+  ['quote', { module: 'string', replacement: 'string.quote' }],
+  ['str-index', { module: 'string', replacement: 'string.index' }],
+  ['str-insert', { module: 'string', replacement: 'string.insert' }],
+  ['str-length', { module: 'string', replacement: 'string.length' }],
+  ['str-slice', { module: 'string', replacement: 'string.slice' }],
+  ['to-lower-case', { module: 'string', replacement: 'string.to-lower-case' }],
+  ['to-upper-case', { module: 'string', replacement: 'string.to-upper-case' }],
+  ['unique-id', { module: 'string', replacement: 'string.unique-id' }],
+  ['unquote', { module: 'string', replacement: 'string.unquote' }],
+]);
+
+/**
+ * Build a single regex that matches any deprecated global function call.
+ * Uses a negative lookbehind to avoid matching namespaced calls (e.g.
+ * `color.adjust(`) and a word boundary / hyphen-aware pattern so that
+ * partial names don't match.
+ *
+ * @returns A global RegExp that captures the deprecated function name
+ */
+function buildFunctionCallRegex(): RegExp {
+  const names = [...DEPRECATED_FUNCTIONS.keys()].map(escapeRegExp);
+  // Sort longest-first so `adjust-color` matches before `adjust`
+  names.sort((a, b) => b.length - a.length);
+  // Negative lookbehind: not preceded by `.` or `$` or word char
+  // Lookahead: followed by `(`
+  return new RegExp(`(?<![.$\\w-])(?:${names.join('|')})(?=\\()`, 'g');
+}
+
+/**
+ * Escape special regex characters in a string.
+ *
+ * @param s - The string to escape
+ * @returns The escaped string safe for use in a RegExp
+ */
+function escapeRegExp(s: string): string {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+/** Pre-compiled regex for matching deprecated function calls in values. */
+const FUNCTION_CALL_RE = buildFunctionCallRegex();
+
+/**
+ * Diagnostic messages produced by this rule.
+ *
+ * @param name - The deprecated global function name
+ * @param replacement - The recommended namespaced replacement
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: (name: string, replacement: string) =>
+    `Unexpected global function '${name}'. Use '${replacement}' instead`,
+});
+
+/**
+ * Stylelint rule function for `sass/no-global-function-names`.
+ *
+ * Walks all declarations (including `$variable` declarations) and
+ * at-rules, searching values for calls to deprecated global Sass
+ * functions.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback that walks nodes
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    /**
+     * Check a string value for deprecated global function calls and
+     * report any matches.
+     */
+    function checkValue(value: string, node: import('postcss').Node): void {
+      FUNCTION_CALL_RE.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = FUNCTION_CALL_RE.exec(value)) !== null) {
+        const name = match[0];
+        const entry = DEPRECATED_FUNCTIONS.get(name);
+        /* istanbul ignore next -- safety guard */
+        if (!entry) continue;
+        utils.report({
+          message: messages.rejected(name, entry.replacement),
+          node,
+          result,
+          ruleName,
+        });
+      }
+    }
+
+    // Check declaration values (includes $variable declarations)
+    root.walkDecls((decl) => {
+      checkValue(decl.value, decl);
+    });
+
+    // Check at-rule params (e.g. @if unitless($val), @return percentage(0.5))
+    root.walkAtRules((atRule) => {
+      if (atRule.params) {
+        checkValue(atRule.params, atRule);
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Summary

- Add `sass/no-global-function-names` rule that disallows deprecated global Sass function names
  (e.g. `darken()`, `map-get()`, `unitless()`) and suggests their namespaced replacements
  (e.g. `color.adjust()`, `map.get()`, `math.is-unitless()`)
- Comprehensive lookup table covering ~70 deprecated functions from sass:color, sass:list,
  sass:map, sass:math, sass:meta, sass:selector, and sass:string modules
- CSS-native functions (`min`, `max`, `round`, `abs`, `invert`, `grayscale`, `saturate`,
  `alpha`, `opacity`) are intentionally excluded to prevent false positives on valid CSS
- Regex-based detection with negative lookbehind to avoid matching namespaced calls
- Registered in plugin entry point and recommended config

## Test plan

- [x] `pnpm check` passes (typecheck + lint + format + test)
- [x] 31 tests: 16 BAD cases (deprecated globals), 6 GOOD cases (namespaced + user-defined),
  9 CSS-native regression tests (min, max, round, abs, invert, grayscale, saturate, alpha, opacity)
- [x] Edge cases: multiple deprecated calls in one declaration, function name as class substring

🤖 Generated with [Claude Code](https://claude.com/claude-code)