### PR TITLE
Closes #18: add sass/at-use-no-redundant-alias rule

### DIFF
--- a/docs/rules/at-use-no-redundant-alias.md
+++ b/docs/rules/at-use-no-redundant-alias.md
@@ -1,0 +1,115 @@
+# sass/at-use-no-redundant-alias
+
+Disallow `@use` rules where the `as` alias matches the default namespace.
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+Sass's `@use` rule loads a module and automatically assigns it a namespace based on the last
+segment of the URL. For example, `@use "theme/colors"` makes the module available as `colors` —
+you access its members via `colors.$primary`, `colors.adjust()`, etc.
+
+You can override this default with an explicit `as` alias:
+
+```sass
+@use "theme/colors" as palette
+
+.link
+  color: palette.$primary
+```
+
+However, when the alias matches the default namespace, the `as` clause adds nothing:
+
+```sass
+// These two are identical — the second just adds noise
+@use "theme/colors"
+@use "theme/colors" as colors
+```
+
+The same applies to built-in modules:
+
+```sass
+// Redundant — sass:math already defaults to "math"
+@use "sass:math" as math
+
+// Clean — relies on the default
+@use "sass:math"
+```
+
+This rule flags `@use` rules where the explicit alias is identical to what Sass would assign
+automatically. Removing the redundant `as` clause keeps stylesheets concise and reduces visual
+noise. Note that `@forward` rules are not checked — they have different aliasing semantics.
+
+## Configuration
+
+```json
+{
+  "sass/at-use-no-redundant-alias": true
+}
+```
+
+## BAD
+
+```sass
+// alias matches filename
+@use "colors" as colors
+```
+
+```sass
+// alias matches last path segment
+@use "src/utils/helpers" as helpers
+```
+
+```sass
+// alias matches built-in module name
+@use "sass:math" as math
+```
+
+```sass
+// another built-in with redundant alias
+@use "sass:color" as color
+```
+
+```sass
+// alias matches filename without leading underscore
+@use "_variables" as variables
+```
+
+## GOOD
+
+```sass
+// no alias, uses default namespace
+@use "colors"
+```
+
+```sass
+// short alias, different from default
+@use "colors" as c
+```
+
+```sass
+// built-in with default namespace
+@use "sass:math"
+```
+
+```sass
+// built-in with short alias
+@use "sass:math" as m
+```
+
+```sass
+// alias differs from default namespace
+@use "variables" as vars
+```
+
+```sass
+// unnamespaced (separate rule handles this)
+@use "colors" as *
+```
+
+```sass
+// @forward is NOT flagged
+@forward "colors" as colors
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import atExtendNoMissingPlaceholder from './rules/at-extend-no-missing-placehold
 import extendsBeforeDeclarations from './rules/extends-before-declarations/index.js';
 import mixinsBeforeDeclarations from './rules/mixins-before-declarations/index.js';
 import noGlobalFunctionNames from './rules/no-global-function-names/index.js';
+import atUseNoRedundantAlias from './rules/at-use-no-redundant-alias/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -30,6 +31,7 @@ const rules: stylelint.Plugin[] = [
   extendsBeforeDeclarations,
   mixinsBeforeDeclarations,
   noGlobalFunctionNames,
+  atUseNoRedundantAlias,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -57,5 +57,6 @@ export default {
     'sass/extends-before-declarations': true,
     'sass/mixins-before-declarations': true,
     'sass/no-global-function-names': true,
+    'sass/at-use-no-redundant-alias': true,
   },
 };

--- a/src/rules/at-use-no-redundant-alias/index.test.ts
+++ b/src/rules/at-use-no-redundant-alias/index.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/at-use-no-redundant-alias': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/at-use-no-redundant-alias', () => {
+  // BAD cases — should report
+
+  it('rejects alias matching filename', async () => {
+    const result = await lint('@use "colors" as colors');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-use-no-redundant-alias');
+    expect(result.warnings[0].text).toContain('colors');
+  });
+
+  it('rejects alias matching last path segment', async () => {
+    const result = await lint('@use "src/utils/helpers" as helpers');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-use-no-redundant-alias');
+    expect(result.warnings[0].text).toContain('helpers');
+  });
+
+  it('rejects alias matching built-in module name (sass:math)', async () => {
+    const result = await lint('@use "sass:math" as math');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-use-no-redundant-alias');
+    expect(result.warnings[0].text).toContain('math');
+  });
+
+  it('rejects alias matching built-in module name (sass:color)', async () => {
+    const result = await lint('@use "sass:color" as color');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-use-no-redundant-alias');
+    expect(result.warnings[0].text).toContain('color');
+  });
+
+  it('rejects alias matching filename without leading underscore', async () => {
+    const result = await lint('@use "_variables" as variables');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-use-no-redundant-alias');
+    expect(result.warnings[0].text).toContain('variables');
+  });
+
+  it('rejects alias matching filename with extension stripped', async () => {
+    const result = await lint('@use "theme/config.scss" as config');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-use-no-redundant-alias');
+  });
+
+  it('rejects redundant alias followed by inline comment', async () => {
+    const result = await lint('@use "colors" as colors // theme colors');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].text).toContain('colors');
+  });
+
+  // GOOD cases — should NOT report
+
+  it('accepts @use with no alias (default namespace)', async () => {
+    const result = await lint('@use "colors"');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @use with a short alias different from default', async () => {
+    const result = await lint('@use "colors" as c');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts built-in with default namespace', async () => {
+    const result = await lint('@use "sass:math"');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts built-in with short alias', async () => {
+    const result = await lint('@use "sass:math" as m');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts alias that differs from default namespace', async () => {
+    const result = await lint('@use "variables" as vars');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @use with as * (unnamespaced)', async () => {
+    const result = await lint('@use "colors" as *');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('does not flag @forward', async () => {
+    const result = await lint('@forward "colors" as colors-*');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/at-use-no-redundant-alias/index.ts
+++ b/src/rules/at-use-no-redundant-alias/index.ts
@@ -1,0 +1,146 @@
+/**
+ * Rule: `sass/at-use-no-redundant-alias`
+ *
+ * Disallow `@use` rules where the `as` alias matches the default namespace.
+ * Sass already defaults the namespace to the last segment of the URL
+ * (without extension or leading underscore), so an explicit alias that
+ * matches adds noise without changing behavior.
+ *
+ * @example
+ * ```sass
+ * // BAD — alias matches the default namespace
+ * @use "colors" as colors
+ *
+ * // GOOD — no alias needed; default namespace is already "colors"
+ * @use "colors"
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/at-use-no-redundant-alias';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/at-use-no-redundant-alias.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: (alias: string) =>
+    `Unexpected redundant alias '${alias}'. The default namespace is already '${alias}'`,
+});
+
+/**
+ * Computes the default namespace for a `@use` URL.
+ *
+ * For built-in modules like `sass:math`, the default namespace is
+ * the part after the colon (e.g. `math`). For file paths, it is
+ * the last segment without extension or leading underscore.
+ *
+ * @param url - The unquoted URL string from the `@use` rule
+ * @returns The computed default namespace
+ *
+ * @example
+ * ```ts
+ * computeDefaultNamespace('sass:math')    // 'math'
+ * computeDefaultNamespace('src/utils/_helpers.scss') // 'helpers'
+ * computeDefaultNamespace('colors')       // 'colors'
+ * ```
+ */
+function computeDefaultNamespace(url: string): string {
+  // Built-in modules: sass:xxx -> xxx
+  if (url.startsWith('sass:')) {
+    return url.slice(5);
+  }
+
+  // File paths: take last segment, strip extension and leading underscore
+  const lastSegment = url.split('/').pop() ?? url;
+  const withoutExtension = lastSegment.replace(/\.[^.]+$/, '');
+  const withoutUnderscore = withoutExtension.replace(/^_/, '');
+
+  return withoutUnderscore;
+}
+
+/**
+ * Extracts the original source text for a node from its source map.
+ *
+ * @param node - The PostCSS at-rule node
+ * @returns The original source text, or `undefined` if unavailable
+ */
+function getOriginalSource(node: {
+  source?: { input: { css: string }; start?: { offset: number }; end?: { offset: number } };
+}): string | undefined {
+  if (!node.source?.start || !node.source?.end) return undefined;
+  return node.source.input.css.slice(node.source.start.offset, node.source.end.offset + 1);
+}
+
+/**
+ * Stylelint rule function for `sass/at-use-no-redundant-alias`.
+ *
+ * Uses the original source text to detect whether the user explicitly
+ * wrote an `as` alias that matches the default namespace. sass-parser
+ * normalizes the `params` property and strips redundant aliases, so
+ * we must inspect the raw source to detect this pattern.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback that walks `@use` at-rules
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    root.walkAtRules('use', (node) => {
+      const original = getOriginalSource(node);
+      if (!original) return;
+
+      // Strip inline comments before matching the `as` clause
+      const cleaned = original
+        .replace(/\/\/.*$/, '')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .trim();
+
+      // Check if the cleaned source contains an explicit `as` clause
+      const asMatch = cleaned.match(/\bas\s+(\S+)\s*$/);
+      if (!asMatch) return;
+
+      const alias = asMatch[1];
+
+      // Skip `as *` (unnamespaced — that's a different rule)
+      if (alias === '*') return;
+
+      // Extract the URL from the original source
+      const urlMatch = original.match(/(['"])(.+?)\1/);
+      if (!urlMatch) return;
+
+      const url = urlMatch[2]!;
+      const defaultNamespace = computeDefaultNamespace(url);
+
+      if (alias === defaultNamespace) {
+        utils.report({
+          message: messages.rejected(alias),
+          node,
+          result,
+          ruleName,
+        });
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Description

Add `sass/at-use-no-redundant-alias` rule that flags `@use` rules where the `as` alias matches the default namespace (e.g. `@use "colors" as colors` is redundant). Uses raw source text inspection because sass-parser normalizes away redundant aliases. `computeDefaultNamespace()` handles `sass:*` built-ins, file paths, extensions, and leading underscores. Only checks `@use` rules — `@forward` is intentionally excluded. Registered in plugin entry point and recommended config.

## Test plan

- [x] `pnpm check` passes (typecheck + lint + format + test)
- [x] 13 tests: 6 BAD cases (filename, path segment, built-ins, underscore prefix, extension), 7 GOOD cases (no alias, different alias, `as *`, `@forward`)