### PR TITLE
Closes #21: add sass/at-if-no-null rule

### DIFF
--- a/docs/rules/at-if-no-null.md
+++ b/docs/rules/at-if-no-null.md
@@ -1,0 +1,113 @@
+# sass/at-if-no-null
+
+Disallow explicit `null` comparisons in `@if` conditions. Sass truthiness checks already handle
+`null` implicitly, so `@if $x != null` can be replaced with `@if $x` and `@if $x == null` can be
+replaced with `@if not $x`.
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+In Sass, `null` is a falsy value — it behaves like `false` in boolean contexts. This means explicit
+comparisons against `null` are always redundant:
+
+- `@if $x != null` is equivalent to `@if $x`, because `$x` is already truthy when it holds any
+  non-null, non-false value.
+- `@if $x == null` is equivalent to `@if not $x`, because `not $x` evaluates to `true` when `$x` is
+  `null` (or `false`).
+
+```sass
+// Verbose — the != null check adds nothing
+@if $color != null
+  background: $color
+
+// Idiomatic — relies on Sass truthiness
+@if $color
+  background: $color
+```
+
+Removing explicit `null` comparisons makes conditions shorter, more readable, and consistent with
+Sass's own truthiness model. It also avoids a common pitfall where developers assume `null` needs
+special handling, when Sass already treats it identically to `false` in conditionals.
+
+## Configuration
+
+```json
+{
+  "sass/at-if-no-null": true
+}
+```
+
+## BAD
+
+```sass
+// unnecessary != null check; use @if $x instead
+@if $x != null
+  color: red
+```
+
+```sass
+// use @if not $x instead of comparing to null
+@if $x == null
+  @warn "x is not set"
+```
+
+```sass
+// verbose null guard on a realistic variable
+@if $color != null
+  background-color: $color
+@else
+  background-color: transparent
+```
+
+```sass
+// verbose null guard on a map variable
+@if $map != null
+  $value: map-get($map, key)
+  font-size: $value
+```
+
+```sass
+// reversed operand order is equally unnecessary
+@if null != $x
+  display: block
+```
+
+## GOOD
+
+```sass
+// truthiness check — already false when $x is null
+@if $x
+  color: red
+```
+
+```sass
+// falsy check — covers null without explicit comparison
+@if not $x
+  @warn "x is not set"
+```
+
+```sass
+// explicit false check is a different intent, not flagged
+@if $x == false
+  @error "x was explicitly set to false"
+```
+
+```sass
+// numeric comparison, not a null check
+@if $x > 0
+  margin-top: $x
+```
+
+```sass
+// boolean combination using truthiness
+@if $x and $y
+  border: 1px solid $x
+```
+
+```sass
+// type check — not a null comparison
+@if type-of($x) == "number"
+  font-size: $x * 1px
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import extendsBeforeDeclarations from './rules/extends-before-declarations/index
 import mixinsBeforeDeclarations from './rules/mixins-before-declarations/index.js';
 import noGlobalFunctionNames from './rules/no-global-function-names/index.js';
 import atUseNoRedundantAlias from './rules/at-use-no-redundant-alias/index.js';
+import atIfNoNull from './rules/at-if-no-null/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -32,6 +33,7 @@ const rules: stylelint.Plugin[] = [
   mixinsBeforeDeclarations,
   noGlobalFunctionNames,
   atUseNoRedundantAlias,
+  atIfNoNull,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -58,5 +58,6 @@ export default {
     'sass/mixins-before-declarations': true,
     'sass/no-global-function-names': true,
     'sass/at-use-no-redundant-alias': true,
+    'sass/at-if-no-null': true,
   },
 };

--- a/src/rules/at-if-no-null/index.test.ts
+++ b/src/rules/at-if-no-null/index.test.ts
@@ -1,0 +1,113 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/at-if-no-null': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/at-if-no-null', () => {
+  // BAD cases — should warn
+
+  it('rejects @if $x != null', async () => {
+    const result = await lint('.foo\n  @if $x != null\n    color: red');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-if-no-null');
+  });
+
+  it('rejects @if $x == null', async () => {
+    const result = await lint('@if $x == null\n  @warn "x is not set"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-if-no-null');
+  });
+
+  it('rejects @if $color != null (realistic variable)', async () => {
+    const result = await lint(
+      '.foo\n  @if $color != null\n    background-color: $color\n  @else\n    background-color: transparent',
+    );
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-if-no-null');
+  });
+
+  it('rejects @if $map != null (map variable)', async () => {
+    const result = await lint(
+      '.foo\n  @if $map != null\n    $value: map-get($map, key)\n    font-size: $value',
+    );
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-if-no-null');
+  });
+
+  it('rejects @if null != $x (reversed operand order)', async () => {
+    const result = await lint('.foo\n  @if null != $x\n    display: block');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-if-no-null');
+  });
+
+  it('rejects @if $x ==null (no space before null)', async () => {
+    const result = await lint('.foo\n  @if $x ==null\n    display: block');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-if-no-null');
+  });
+
+  it('rejects @if $x!=null (no spaces around operator)', async () => {
+    const result = await lint('.foo\n  @if $x!=null\n    display: block');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-if-no-null');
+  });
+
+  it('rejects @if null!=$x (no spaces, reversed)', async () => {
+    const result = await lint('.foo\n  @if null!=$x\n    display: block');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-if-no-null');
+  });
+
+  it('rejects @if $x != null and $y (compound condition)', async () => {
+    const result = await lint('.foo\n  @if $x != null and $y\n    display: block');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-if-no-null');
+  });
+
+  // GOOD cases — should not warn
+
+  it('accepts @if $x (truthiness check)', async () => {
+    const result = await lint('.foo\n  @if $x\n    color: red');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @if not $x (falsy check)', async () => {
+    const result = await lint('@if not $x\n  @warn "x is not set"');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @if $x == false (explicit false check)', async () => {
+    const result = await lint('@if $x == false\n  @error "x was explicitly set to false"');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @if $x > 0 (numeric comparison)', async () => {
+    const result = await lint('.foo\n  @if $x > 0\n    margin-top: $x');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @if $x and $y (boolean combination)', async () => {
+    const result = await lint('.foo\n  @if $x and $y\n    border: 1px solid $x');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @if type-of($x) == "number" (type check)', async () => {
+    const result = await lint('.foo\n  @if type-of($x) == "number"\n    font-size: $x * 1px');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/at-if-no-null/index.ts
+++ b/src/rules/at-if-no-null/index.ts
@@ -1,0 +1,81 @@
+/**
+ * Rule: `sass/at-if-no-null`
+ *
+ * Disallow explicit `null` comparisons in `@if` conditions.
+ * Sass truthiness checks already handle `null` implicitly, so
+ * `@if $x != null` can be replaced with `@if $x` and
+ * `@if $x == null` can be replaced with `@if not $x`.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule
+ * @if $x != null
+ *   color: red
+ *
+ * // GOOD — use truthiness instead
+ * @if $x
+ *   color: red
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/at-if-no-null';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/at-if-no-null.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: 'Unexpected null comparison. Use Sass truthiness instead',
+});
+
+/**
+ * Pattern that matches explicit null comparisons in `@if` conditions.
+ *
+ * Matches both `$var == null`, `$var != null` and reversed forms
+ * like `null == $var`, `null != $var`.
+ */
+const nullComparisonPattern = /\bnull\b\s*(?:==|!=)|(?:==|!=)\s*\bnull\b/;
+
+/**
+ * Stylelint rule function for `sass/at-if-no-null`.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback that walks `@if` at-rules
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    root.walkAtRules('if', (node) => {
+      if (nullComparisonPattern.test(node.params)) {
+        utils.report({
+          message: messages.rejected,
+          node,
+          result,
+          ruleName,
+        });
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Description

- Add `sass/at-if-no-null` rule that disallows explicit `null` comparisons in `@if` conditions
- Sass truthiness already handles `null` implicitly — `@if $x != null` can be `@if $x`, and `@if $x == null` can be `@if not $x`
- Regex-based detection covers both operand orderings and no-space variants
- Enabled in the recommended config
- Documentation includes `## Why?` section explaining Sass truthiness semantics

## Test plan

- [x] `pnpm check` passes (182 tests)
- [x] 9 BAD cases: `== null`, `!= null`, reversed operand order, no-space variants, compound conditions
- [x] 6 GOOD cases: truthiness, `not`, `== false`, numeric comparison, boolean combination, `type-of`