### PR TITLE
Closes #20: add sass/mixins-before-declarations rule

### DIFF
--- a/docs/rules/mixins-before-declarations.md
+++ b/docs/rules/mixins-before-declarations.md
@@ -1,0 +1,134 @@
+# sass/mixins-before-declarations
+
+Enforce that `@include` (or `+` shorthand) statements appear before property declarations within a
+rule block.
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+Sass mixins (`@include` or `+` shorthand) inject a reusable block of styles into a rule. They can
+set any number of properties, so their effect on the final output depends on where they appear
+relative to explicit declarations. Placing mixins before declarations makes the rule block read
+top-down: "apply these shared patterns, then set these specific properties."
+
+```sass
+// Hard to read — does +rounded override padding, or does padding override +rounded?
+.card
+  padding: 16px
+  +rounded
+  background: white
+```
+
+When mixins come first, the intent is unambiguous — explicit declarations always win because they
+come last:
+
+```sass
+// Clear — apply shared mixin, then set specific properties
+.card
+  +rounded
+  padding: 16px
+  background: white
+```
+
+Some mixins like responsive wrappers (`+respond-to`) use `@content` and naturally belong near the
+declarations they affect. Use the `ignore` option to exempt these from the ordering requirement.
+
+## Configuration
+
+```json
+{
+  "sass/mixins-before-declarations": true
+}
+```
+
+### Options
+
+#### `ignore: string[]`
+
+Exempt specific mixin names from the ordering requirement. Useful for responsive or conditional
+mixins that wrap `@content` and belong near the declarations they affect.
+
+```json
+{
+  "sass/mixins-before-declarations": [true, { "ignore": ["respond-to"] }]
+}
+```
+
+## BAD
+
+```sass
+// +include shorthand after declaration
+.card
+  padding: 16px
+  +rounded
+```
+
+```sass
+// @include after declaration
+.card
+  padding: 16px
+  @include rounded
+```
+
+```sass
+// Mixin between declarations
+.hero
+  display: flex
+  +respond-to(md)
+    flex-direction: row
+  color: white
+```
+
+```sass
+// Multiple mixins, some after declarations
+.btn
+  +reset
+  background: blue
+  +hover-state
+```
+
+## GOOD
+
+```sass
+// Mixins before declarations
+.card
+  +rounded
+  padding: 16px
+  background: white
+```
+
+```sass
+// Multiple mixins before declarations
+.btn
+  +reset
+  +hover-state
+  background: blue
+  padding: 8px
+```
+
+```sass
+// @include syntax before declarations
+.card
+  @include rounded
+  @include shadow(2)
+  padding: 16px
+```
+
+```sass
+// With ignore: ["respond-to"] — responsive mixin wrapping @content is exempt
+.grid
+  +flex-layout
+  display: grid
+  gap: 16px
+  +respond-to(md)
+    grid-template-columns: repeat(2, 1fr)
+```
+
+```sass
+// Only mixins, no declarations
+.icon
+  +size(24px)
+  +center
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import percentPlaceholderPattern from './rules/percent-placeholder-pattern/index
 import atFunctionPattern from './rules/at-function-pattern/index.js';
 import atExtendNoMissingPlaceholder from './rules/at-extend-no-missing-placeholder/index.js';
 import extendsBeforeDeclarations from './rules/extends-before-declarations/index.js';
+import mixinsBeforeDeclarations from './rules/mixins-before-declarations/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -26,6 +27,7 @@ const rules: stylelint.Plugin[] = [
   atFunctionPattern,
   atExtendNoMissingPlaceholder,
   extendsBeforeDeclarations,
+  mixinsBeforeDeclarations,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -55,5 +55,6 @@ export default {
     'sass/at-function-pattern': [/^[a-z][a-z0-9]*(-[a-z0-9]+)*$/],
     'sass/at-extend-no-missing-placeholder': true,
     'sass/extends-before-declarations': true,
+    'sass/mixins-before-declarations': true,
   },
 };

--- a/src/rules/mixins-before-declarations/index.test.ts
+++ b/src/rules/mixins-before-declarations/index.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/mixins-before-declarations': true },
+};
+
+async function lint(code: string, overrides?: object) {
+  const result = await stylelint.lint({ code, config: { ...config, ...overrides } });
+  return result.results[0]!;
+}
+
+describe('sass/mixins-before-declarations', () => {
+  // BAD cases
+  it('rejects +include shorthand after declaration', async () => {
+    const result = await lint('.card\n  padding: 16px\n  +rounded');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/mixins-before-declarations');
+  });
+
+  it('rejects @include after declaration', async () => {
+    const result = await lint('.card\n  padding: 16px\n  @include rounded');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/mixins-before-declarations');
+  });
+
+  it('rejects mixin between declarations', async () => {
+    const result = await lint(
+      '.hero\n  display: flex\n  +respond-to(md)\n    flex-direction: row\n  color: white',
+    );
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('rejects multiple mixins when some are after declarations', async () => {
+    const result = await lint('.btn\n  +reset\n  background: blue\n  +hover-state');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  // GOOD cases
+  it('accepts mixins before declarations', async () => {
+    const result = await lint('.card\n  +rounded\n  padding: 16px\n  background: white');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts multiple mixins before declarations', async () => {
+    const result = await lint('.btn\n  +reset\n  +hover-state\n  background: blue\n  padding: 8px');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @include syntax before declarations', async () => {
+    const result = await lint('.card\n  @include rounded\n  @include shadow(2)\n  padding: 16px');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts ignored mixin after declarations', async () => {
+    const result = await lint(
+      '.grid\n  +flex-layout\n  display: grid\n  gap: 16px\n  +respond-to(md)\n    grid-template-columns: repeat(2, 1fr)',
+      {
+        rules: {
+          'sass/mixins-before-declarations': [true, { ignore: ['respond-to'] }],
+        },
+      },
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts rule with only mixins and no declarations', async () => {
+    const result = await lint('.icon\n  +size(24px)\n  +center');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('rejects mixin after declaration inside a nested rule', async () => {
+    const result = await lint('.parent\n  .child\n    padding: 10px\n    +rounded');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/mixins-before-declarations');
+  });
+
+  it('still rejects non-ignored mixin when ignore option is set', async () => {
+    const result = await lint(
+      '.grid\n  display: grid\n  +respond-to(md)\n    gap: 16px\n  +not-ignored',
+      {
+        rules: {
+          'sass/mixins-before-declarations': [true, { ignore: ['respond-to'] }],
+        },
+      },
+    );
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/mixins-before-declarations');
+  });
+
+  it('accepts multiple ignored mixins after declarations', async () => {
+    const result = await lint(
+      '.grid\n  display: grid\n  +respond-to(md)\n    gap: 16px\n  +breakpoint(lg)\n    gap: 24px',
+      {
+        rules: {
+          'sass/mixins-before-declarations': [true, { ignore: ['respond-to', 'breakpoint'] }],
+        },
+      },
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/mixins-before-declarations/index.ts
+++ b/src/rules/mixins-before-declarations/index.ts
@@ -1,0 +1,130 @@
+/**
+ * Rule: `sass/mixins-before-declarations`
+ *
+ * `@include` (or `+` shorthand) statements must appear before property
+ * declarations within a rule block. This enforces a predictable ordering:
+ * mixins first, then properties.
+ *
+ * @example
+ * ```sass
+ * // BAD — +mixin after declaration
+ * .card
+ *   padding: 16px
+ *   +rounded
+ *
+ * // GOOD — +mixin before declarations
+ * .card
+ *   +rounded
+ *   padding: 16px
+ * ```
+ */
+import stylelint from 'stylelint';
+import type { AtRule } from 'postcss';
+import { classifyChild } from '../../utils/ordering.js';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/mixins-before-declarations';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/mixins-before-declarations.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: '@include must come before declarations',
+});
+
+/**
+ * Secondary option type for `sass/mixins-before-declarations`.
+ */
+interface SecondaryOptions {
+  /** Mixin names to exempt from the ordering requirement. */
+  ignore?: string[];
+}
+
+/**
+ * Extracts the mixin name from an at-rule's params string.
+ *
+ * @param params - The raw params string (e.g. `"rounded"` or `"respond-to(md)"`)
+ * @returns The mixin name (first word before `(` or space)
+ *
+ * @example
+ * ```ts
+ * getMixinName('respond-to(md)'); // => 'respond-to'
+ * getMixinName('rounded');        // => 'rounded'
+ * ```
+ */
+function getMixinName(params: string): string {
+  const trimmed = params.trim();
+  const parenIndex = trimmed.indexOf('(');
+  const spaceIndex = trimmed.indexOf(' ');
+
+  let endIndex = trimmed.length;
+  if (parenIndex !== -1) endIndex = Math.min(endIndex, parenIndex);
+  if (spaceIndex !== -1) endIndex = Math.min(endIndex, spaceIndex);
+
+  return trimmed.slice(0, endIndex);
+}
+
+/**
+ * Stylelint rule function for `sass/mixins-before-declarations`.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @param secondaryOptions - Optional secondary options with `ignore` list
+ * @returns A PostCSS plugin callback that walks rule blocks
+ */
+const ruleFunction: stylelint.Rule<true, SecondaryOptions> = (primary, secondaryOptions) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(
+      result,
+      ruleName,
+      { actual: primary },
+      {
+        actual: secondaryOptions,
+        possible: { ignore: [(v: unknown) => typeof v === 'string'] },
+        optional: true,
+      },
+    );
+    if (!validOptions) return;
+
+    const ignoreList = secondaryOptions?.ignore ?? [];
+
+    root.walkRules((rule) => {
+      let seenDeclaration = false;
+
+      rule.each((child) => {
+        const kind = classifyChild(child);
+
+        if (kind === 'declaration') {
+          seenDeclaration = true;
+        } else if (kind === 'include' && seenDeclaration) {
+          // classifyChild already confirmed this is an AtRule with name 'include'
+          const mixinName = getMixinName((child as AtRule).params);
+          if (ignoreList.includes(mixinName)) return;
+
+          utils.report({
+            message: messages.rejected,
+            node: child,
+            result,
+            ruleName,
+          });
+        }
+      });
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Description

- Add `sass/mixins-before-declarations` rule that enforces `@include`/`+` before property declarations
- Supports `ignore` option to exempt specific mixins (e.g. responsive wrappers)
- Handles both `@include mixin` and `+mixin` shorthand syntax
- 12 tests (4 BAD, 5 GOOD, 3 edge cases) including ignore option coverage
- User-facing docs with "Why?" section at `docs/rules/mixins-before-declarations.md`

## Test plan

- [x] `pnpm check` passes
- [x] BAD: +shorthand after, @include after, mixin between declarations, multiple with some after
- [x] GOOD: before declarations, multiple before, @include syntax, ignored mixin, only mixins
- [x] Edge cases: nested rule, non-ignored with ignore set, multiple ignored mixins
- [x] Rule registered in `src/index.ts` and `src/recommended.ts`