### PR TITLE
Closes #24: add sass/declarations-before-nesting rule

### DIFF
--- a/docs/rules/declarations-before-nesting.md
+++ b/docs/rules/declarations-before-nesting.md
@@ -1,0 +1,142 @@
+# sass/declarations-before-nesting
+
+Property declarations must appear before nested rules within a rule block. This enforces a
+predictable ordering: extends, then mixins, then declarations, then nested rules — making it clear
+where base styles end and nested scopes begin.
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+Sass's indented syntax makes it easy to interleave property declarations with nested selectors. When
+declarations are scattered between nested blocks, scanning a rule for its own styles requires reading
+through every child — including unrelated descendants and modifiers:
+
+```sass
+// Hard to scan — where are .card's own styles?
+.card
+  .title
+    font-weight: bold
+  padding: 16px
+  &:hover
+    opacity: 0.9
+  background: white
+```
+
+Grouping all declarations together before any nested rules creates a clear visual boundary: the top
+section is _what this selector looks like_, the bottom section is _how its children and states
+behave_:
+
+```sass
+// Easy to scan — .card's styles are all in one place
+.card
+  padding: 16px
+  background: white
+
+  .title
+    font-weight: bold
+
+  &:hover
+    opacity: 0.9
+```
+
+This rule is part of a three-rule ordering convention (`extends-before-declarations` →
+`mixins-before-declarations` → `declarations-before-nesting`) that together enforce a predictable
+structure inside every rule block.
+
+## Configuration
+
+```json
+{
+  "sass/declarations-before-nesting": true
+}
+```
+
+## BAD
+
+```sass
+// Nested rule before declaration
+.card
+  .title
+    font-weight: bold
+  padding: 16px
+```
+
+```sass
+// Mixed ordering
+.nav
+  color: white
+  .item
+    display: inline-block
+  background: navy
+```
+
+```sass
+// Pseudo-selector nesting before declaration
+.link
+  &:hover
+    text-decoration: underline
+  color: blue
+```
+
+```sass
+// Parent selector nesting before declaration
+.btn
+  &--primary
+    background: blue
+  padding: 8px 16px
+```
+
+## GOOD
+
+```sass
+// Declarations before nested rules
+.card
+  padding: 16px
+  background: white
+
+  .title
+    font-weight: bold
+
+  .body
+    line-height: 1.5
+```
+
+```sass
+// Full ordering (extends → mixins → declarations → nested)
+.card
+  @extend %rounded
+  +shadow(2)
+  padding: 16px
+  background: white
+
+  .title
+    font-weight: bold
+```
+
+```sass
+// Pseudo-selectors after declarations
+.link
+  color: blue
+  text-decoration: none
+
+  &:hover
+    text-decoration: underline
+
+  &:focus
+    outline: 2px solid blue
+```
+
+```sass
+// BEM modifier after declarations
+.btn
+  padding: 8px 16px
+  border: none
+
+  &--primary
+    background: blue
+
+  &--secondary
+    background: gray
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import mixinsBeforeDeclarations from './rules/mixins-before-declarations/index.j
 import noGlobalFunctionNames from './rules/no-global-function-names/index.js';
 import atUseNoRedundantAlias from './rules/at-use-no-redundant-alias/index.js';
 import atIfNoNull from './rules/at-if-no-null/index.js';
+import declarationsBeforeNesting from './rules/declarations-before-nesting/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -34,6 +35,7 @@ const rules: stylelint.Plugin[] = [
   noGlobalFunctionNames,
   atUseNoRedundantAlias,
   atIfNoNull,
+  declarationsBeforeNesting,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -59,5 +59,6 @@ export default {
     'sass/no-global-function-names': true,
     'sass/at-use-no-redundant-alias': true,
     'sass/at-if-no-null': true,
+    'sass/declarations-before-nesting': true,
   },
 };

--- a/src/rules/declarations-before-nesting/index.test.ts
+++ b/src/rules/declarations-before-nesting/index.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/declarations-before-nesting': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/declarations-before-nesting', () => {
+  // BAD cases
+  it('rejects nested rule before declaration', async () => {
+    const result = await lint('.card\n  .title\n    font-weight: bold\n  padding: 16px');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/declarations-before-nesting');
+  });
+
+  it('rejects mixed ordering', async () => {
+    const result = await lint(
+      '.nav\n  color: white\n  .item\n    display: inline-block\n  background: navy',
+    );
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/declarations-before-nesting');
+  });
+
+  it('rejects pseudo-selector nesting before declaration', async () => {
+    const result = await lint('.link\n  &:hover\n    text-decoration: underline\n  color: blue');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/declarations-before-nesting');
+  });
+
+  it('rejects parent selector nesting before declaration', async () => {
+    const result = await lint('.btn\n  &--primary\n    background: blue\n  padding: 8px 16px');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/declarations-before-nesting');
+  });
+
+  // GOOD cases
+  it('accepts declarations before nested rules', async () => {
+    const result = await lint(
+      '.card\n  padding: 16px\n  background: white\n\n  .title\n    font-weight: bold\n\n  .body\n    line-height: 1.5',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts full ordering (extends, mixins, declarations, nested)', async () => {
+    const result = await lint(
+      '.card\n  @extend %rounded\n  +shadow(2)\n  padding: 16px\n  background: white\n\n  .title\n    font-weight: bold',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts pseudo-selectors after declarations', async () => {
+    const result = await lint(
+      '.link\n  color: blue\n  text-decoration: none\n\n  &:hover\n    text-decoration: underline\n\n  &:focus\n    outline: 2px solid blue',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts BEM modifier after declarations', async () => {
+    const result = await lint(
+      '.btn\n  padding: 8px 16px\n  border: none\n\n  &--primary\n    background: blue\n\n  &--secondary\n    background: gray',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Edge cases
+  it('accepts rule block with only declarations', async () => {
+    const result = await lint('.header\n  font-size: 24px\n  margin-bottom: 1rem');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts rule block with only nested rules', async () => {
+    const result = await lint(
+      '.button\n  &:hover\n    opacity: 0.8\n  .icon\n    margin-right: 5px',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts empty rule block', async () => {
+    const result = await lint('.empty\n  // nothing here');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('ignores comments between nested rules and declarations', async () => {
+    const result = await lint(
+      '.card\n  padding: 16px\n  // a comment\n  .title\n    font-weight: bold',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('ignores @media at-rules (not treated as nested rules)', async () => {
+    const result = await lint(
+      '.container\n  @media (min-width: 768px)\n    display: grid\n  padding: 10px',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/declarations-before-nesting/index.ts
+++ b/src/rules/declarations-before-nesting/index.ts
@@ -1,0 +1,87 @@
+/**
+ * Rule: `sass/declarations-before-nesting`
+ *
+ * Property declarations must appear before nested rules within a rule block.
+ * This enforces a predictable ordering: extends, then mixins, then
+ * declarations, then nested rules.
+ *
+ * @example
+ * ```sass
+ * // BAD — nested rule before declaration
+ * .card
+ *   .title
+ *     font-weight: bold
+ *   padding: 16px
+ *
+ * // GOOD — declarations before nested rules
+ * .card
+ *   padding: 16px
+ *   background: white
+ *
+ *   .title
+ *     font-weight: bold
+ * ```
+ */
+import stylelint from 'stylelint';
+import { classifyChild } from '../../utils/ordering.js';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/declarations-before-nesting';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/declarations-before-nesting.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: 'Declarations must come before nested rules',
+});
+
+/**
+ * Stylelint rule function for `sass/declarations-before-nesting`.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback that walks rule blocks
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    root.walkRules((rule) => {
+      let seenNestedRule = false;
+
+      rule.each((child) => {
+        const kind = classifyChild(child);
+
+        if (kind === 'nested-rule') {
+          seenNestedRule = true;
+        } else if (kind === 'declaration' && seenNestedRule) {
+          utils.report({
+            message: messages.rejected,
+            node: child,
+            result,
+            ruleName,
+          });
+        }
+      });
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Description

- Add `sass/declarations-before-nesting` rule enforcing property declarations before nested rules
- Uses shared `classifyChild` utility from `src/utils/ordering.ts` for consistent child node classification
- Correctly excludes `@media`/`@if` and other at-rules from nested-rule detection
- Enabled in the recommended config
- Documentation includes `## Why?` section explaining the ordering convention and visual scanning benefits

## Test plan

- [x] `pnpm check` passes (195 tests)
- [x] 4 BAD cases: nested before decl, mixed ordering, pseudo-selector, parent selector
- [x] 5 GOOD cases: decls-first, full ordering, pseudo after, BEM after, only declarations
- [x] 4 edge cases: only nested, empty rule, comments, @media not treated as nested