### PR TITLE
Closes #53: add Dev Container configuration for contributors

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,63 @@
+# Dev Container
+
+A sandboxed development environment for stylelint-sass. Pre-installs Node 22, pnpm, gh CLI,
+Graphite CLI, and Claude Code so contributors can start working immediately.
+
+## Why a Dev Container?
+
+The Dev Container provides an **isolated environment** where you can safely run Claude Code with
+full permissions (`--dangerously-skip-permissions`). This lets subagents work autonomously without
+risking your host machine. Outside a sandbox, every tool call requires manual approval, which
+defeats the purpose of agentic workflows.
+
+## Opening the project
+
+### VS Code
+
+1. Install the
+   [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+   extension
+2. Open the repo folder in VS Code
+3. When prompted "Reopen in Container", click it — or run **Dev Containers: Reopen in Container**
+   from the Command Palette (`Cmd+Shift+P` / `Ctrl+Shift+P`)
+4. Wait for the container to build (first time takes a few minutes)
+
+### Cursor
+
+1. Install the
+   [Dev Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+   extension (Cursor supports VS Code extensions)
+2. Open the repo folder in Cursor
+3. Run **Dev Containers: Reopen in Container** from the Command Palette (`Cmd+Shift+P` /
+   `Ctrl+Shift+P`)
+4. Wait for the container to build
+
+### GitHub Codespaces
+
+1. Go to the repo on GitHub
+2. Click **Code > Codespaces > Create codespace on main**
+3. The environment builds automatically with all tools pre-installed
+
+## Using Claude Code
+
+Inside the container, a `claude!` alias is available that starts Claude Code with full permissions:
+
+```bash
+claude!
+```
+
+This is equivalent to `claude --dangerously-skip-permissions`. It is safe to use because the
+container is isolated from your host machine.
+
+## What's included
+
+| Tool            | Purpose                                  |
+| --------------- | ---------------------------------------- |
+| Node 22 + pnpm  | Runtime and package manager              |
+| gh CLI          | GitHub issue/PR management               |
+| Graphite CLI    | Stacked PRs and branch workflow          |
+| Claude Code     | AI-powered development assistant         |
+| ESLint          | Linting (via VS Code extension)          |
+| Prettier        | Formatting (via VS Code extension)       |
+| markdownlint    | Markdown linting (via VS Code extension) |
+| Vitest Explorer | Test runner (via VS Code extension)      |

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "stylelint-sass",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:22",
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "pnpm install && npm i -g @anthropic-ai/claude-code @withgraphite/graphite-cli && echo \"alias claude!='claude --dangerously-skip-permissions'\" >> ~/.bashrc",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode",
+        "DavidAnson.vscode-markdownlint",
+        "vitest.explorer"
+      ],
+      "settings": {
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.formatOnSave": true,
+        "editor.tabSize": 2
+      }
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,60 @@
+# stylelint-sass
+
+A [Stylelint](https://stylelint.io/) plugin for linting `.sass` (indented syntax) files. Built on
+[sass-parser](https://www.npmjs.com/package/sass-parser) (official, PostCSS-compatible, maintained
+by the Sass team).
+
+## Installation
+
+```bash
+npm install --save-dev stylelint sass-parser stylelint-sass
+```
+
+Peer dependencies: `stylelint >= 16` and `sass-parser >= 0.4`.
+
+## Usage
+
+```js
+// stylelint.config.js
+export default {
+  customSyntax: 'sass-parser',
+  extends: ['stylelint-sass/recommended'],
+};
+```
+
+```bash
+npx stylelint "src/**/*.sass"
+```
+
+## Rules
+
+<!-- markdownlint-disable MD013 -->
+
+| Rule                                                                                      | Default      | Category    |
+| ----------------------------------------------------------------------------------------- | ------------ | ----------- |
+| [`sass/no-debug`](docs/rules/no-debug.md)                                                 | `true`       | Disallow    |
+| [`sass/no-warn`](docs/rules/no-warn.md)                                                   | `true`       | Disallow    |
+| [`sass/no-import`](docs/rules/no-import.md)                                               | `true`       | Disallow    |
+| [`sass/at-extend-no-missing-placeholder`](docs/rules/at-extend-no-missing-placeholder.md) | `true`       | @extend     |
+| [`sass/dollar-variable-pattern`](docs/rules/dollar-variable-pattern.md)                   | `kebab-case` | Naming      |
+| [`sass/percent-placeholder-pattern`](docs/rules/percent-placeholder-pattern.md)           | `kebab-case` | Naming      |
+| [`sass/at-mixin-pattern`](docs/rules/at-mixin-pattern.md)                                 | `kebab-case` | Naming      |
+| [`sass/at-function-pattern`](docs/rules/at-function-pattern.md)                           | `kebab-case` | Naming      |
+| [`sass/no-global-function-names`](docs/rules/no-global-function-names.md)                 | `true`       | Modern Sass |
+| [`sass/at-use-no-redundant-alias`](docs/rules/at-use-no-redundant-alias.md)               | `true`       | Modern Sass |
+| [`sass/at-if-no-null`](docs/rules/at-if-no-null.md)                                       | `true`       | Modern Sass |
+| [`sass/extends-before-declarations`](docs/rules/extends-before-declarations.md)           | `true`       | Ordering    |
+| [`sass/mixins-before-declarations`](docs/rules/mixins-before-declarations.md)             | `true`       | Ordering    |
+| [`sass/declarations-before-nesting`](docs/rules/declarations-before-nesting.md)           | `true`       | Ordering    |
+
+<!-- markdownlint-enable MD013 -->
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the development workflow, branch naming conventions,
+and rule implementation guide.
+
+The fastest way to get a working dev environment is with a
+[Dev Container](.devcontainer/README.md) — open the repo in VS Code or Cursor and run
+**Dev Containers: Reopen in Container**. Everything (Node 22, pnpm, gh CLI, Graphite CLI,
+Claude Code) is pre-installed.


### PR DESCRIPTION
## Description

- Add `.devcontainer/devcontainer.json` with Node 22, pnpm, gh CLI, Graphite CLI, and Claude Code pre-installed
- Add `claude!` shell alias for running Claude Code with `--dangerously-skip-permissions` inside the sandboxed container
- Add `.devcontainer/README.md` with setup instructions for VS Code, Cursor, and GitHub Codespaces
- Add root `README.md` with installation, usage, rules table, and contributing section linking to the Dev Container for contributor onboarding

## Test plan

- [x] `pnpm check` passes (typecheck + lint + format + test)
- [x] devcontainer.json uses official Microsoft Node 22 image
- [x] postCreateCommand installs all required tools
- [x] Documentation covers VS Code, Cursor, and Codespaces workflows
- [x] README leads with user-facing content (install, usage, rules), contributor setup at the end

🤖 Generated with [Claude Code](https://claude.com/claude-code)