### PR TITLE
Closes #10: add sass/at-use-no-unnamespaced rule

### DIFF
--- a/docs/rules/at-use-no-unnamespaced.md
+++ b/docs/rules/at-use-no-unnamespaced.md
@@ -1,0 +1,115 @@
+# sass/at-use-no-unnamespaced
+
+Disallow `@use` with `as *` (unnamespaced).
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+Sass's `@use` rule loads members (variables, mixins, functions) from another module into the
+current file. By default, members are accessed through a namespace derived from the module's
+filename:
+
+```sass
+@use "variables"
+
+.link
+  color: variables.$primary
+```
+
+The `as *` modifier removes the namespace entirely, dumping all members into the current scope:
+
+```sass
+@use "variables" as *
+
+.link
+  // No namespace — $primary comes from... somewhere
+  color: $primary
+```
+
+This recreates the exact problem that `@import` had: when multiple modules are loaded with `as *`,
+any of them could define `$primary`, and name collisions are silent. The whole point of the Sass
+module system is to eliminate this ambiguity.
+
+Using `as *` with built-in modules is equally problematic — `@use "sass:math" as *` floods the
+scope with dozens of functions (`ceil`, `floor`, `div`, `round`, ...) that shadow any local
+definitions with the same names.
+
+This rule enforces that every `@use` keeps a namespace, whether the default one or an explicit
+short alias via `as <name>`. Note that `@forward ... as *` is intentionally allowed — re-exporting
+all members from a forwarded module is a legitimate pattern for barrel files.
+
+## Configuration
+
+```json
+{
+  "sass/at-use-no-unnamespaced": true
+}
+```
+
+## BAD
+
+```sass
+// @use with as * dumps everything into global scope
+@use "variables" as *
+```
+
+```sass
+// @use built-in module with as *
+@use "sass:math" as *
+```
+
+```sass
+// @use with config and as *
+@use "config" as * with ($primary: #036)
+```
+
+## GOOD
+
+```sass
+// @use with default namespace
+@use "variables"
+
+.link
+  color: variables.$primary
+```
+
+```sass
+// @use with explicit short namespace
+@use "variables" as vars
+
+.link
+  color: vars.$primary
+```
+
+```sass
+// @use built-in with default namespace
+@use "sass:math"
+
+.half
+  width: math.div($width, 2)
+```
+
+```sass
+// @use with explicit namespace for built-in
+@use "sass:color" as c
+
+.link
+  &:hover
+    color: c.adjust($primary, $lightness: -10%)
+```
+
+```sass
+// @forward with as * IS allowed (re-exporting is different)
+@forward "tokens" as *
+```
+
+```sass
+// Multiple namespaced @use
+@use "sass:math"
+@use "sass:color"
+@use "sass:map"
+@use "variables" as vars
+@use "mixins" as mx
+```

--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -1,3 +1,6 @@
+// sass/at-use-no-unnamespaced
+@use "variables" as *
+
 // color-no-invalid-hex
 .invalid-hex
   color: #gggggg

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -54,6 +54,7 @@ describe('recommended config', () => {
         'sass/no-debug',
         'sass/no-warn',
         'sass/no-import',
+        'sass/at-use-no-unnamespaced',
       ]),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,7 @@ import noGlobalFunctionNames from './rules/no-global-function-names/index.js';
 import atUseNoRedundantAlias from './rules/at-use-no-redundant-alias/index.js';
 import atIfNoNull from './rules/at-if-no-null/index.js';
 import declarationsBeforeNesting from './rules/declarations-before-nesting/index.js';
+import atUseNoUnnamespaced from './rules/at-use-no-unnamespaced/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -36,6 +37,7 @@ const rules: stylelint.Plugin[] = [
   atUseNoRedundantAlias,
   atIfNoNull,
   declarationsBeforeNesting,
+  atUseNoUnnamespaced,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -60,5 +60,6 @@ export default {
     'sass/at-use-no-redundant-alias': true,
     'sass/at-if-no-null': true,
     'sass/declarations-before-nesting': true,
+    'sass/at-use-no-unnamespaced': true,
   },
 };

--- a/src/rules/at-use-no-unnamespaced/index.test.ts
+++ b/src/rules/at-use-no-unnamespaced/index.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/at-use-no-unnamespaced': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/at-use-no-unnamespaced', () => {
+  // BAD cases — should report
+
+  it('rejects @use with as * (unnamespaced)', async () => {
+    const result = await lint('@use "variables" as *');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-use-no-unnamespaced');
+  });
+
+  it('rejects @use built-in module with as *', async () => {
+    const result = await lint('@use "sass:math" as *');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-use-no-unnamespaced');
+  });
+
+  it('rejects @use with config and as *', async () => {
+    const result = await lint('@use "config" as * with ($primary: #036)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/at-use-no-unnamespaced');
+  });
+
+  // GOOD cases — should NOT report
+
+  it('accepts @use with default namespace', async () => {
+    const result = await lint('@use "variables"\n\n.link\n  color: red');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @use with explicit short namespace', async () => {
+    const result = await lint('@use "variables" as vars\n\n.link\n  color: red');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @use built-in with default namespace', async () => {
+    const result = await lint('@use "sass:math"');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @use with explicit namespace for built-in', async () => {
+    const result = await lint('@use "sass:color" as c');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @forward with as prefix-* (re-exporting is different)', async () => {
+    const result = await lint('@forward "tokens" as token-*');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts multiple namespaced @use', async () => {
+    const code = [
+      '@use "sass:math"',
+      '@use "sass:color"',
+      '@use "sass:map"',
+      '@use "variables" as vars',
+      '@use "mixins" as mx',
+    ].join('\n');
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/at-use-no-unnamespaced/index.ts
+++ b/src/rules/at-use-no-unnamespaced/index.ts
@@ -1,0 +1,96 @@
+/**
+ * Rule: `sass/at-use-no-unnamespaced`
+ *
+ * Disallow `@use` with `as *` (unnamespaced). Unnamespaced `@use` dumps
+ * all members into the current scope, defeating the purpose of the module
+ * system and risking name collisions — the same problem `@import` had.
+ *
+ * @example
+ * ```sass
+ * // BAD — unnamespaced @use dumps everything into global scope
+ * @use "variables" as *
+ *
+ * // GOOD — use a namespace
+ * @use "variables"
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/at-use-no-unnamespaced';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/at-use-no-unnamespaced.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: 'Unexpected @use with `as *`. Use an explicit namespace instead',
+});
+
+/**
+ * Extracts the original source text for a node from its source map.
+ *
+ * @param node - The PostCSS at-rule node
+ * @returns The original source text, or `undefined` if unavailable
+ */
+function getOriginalSource(node: {
+  source?: { input: { css: string }; start?: { offset: number }; end?: { offset: number } };
+}): string | undefined {
+  if (!node.source?.start || !node.source?.end) return undefined;
+  return node.source.input.css.slice(node.source.start.offset, node.source.end.offset + 1);
+}
+
+/**
+ * Stylelint rule function for `sass/at-use-no-unnamespaced`.
+ *
+ * Walks `@use` at-rules and reports any that contain `as *`.
+ * Uses original source text because sass-parser may normalize params.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback that walks `@use` at-rules
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    root.walkAtRules('use', (node) => {
+      const original = getOriginalSource(node);
+      if (!original) return;
+
+      // Strip inline comments before matching
+      const cleaned = original
+        .replace(/\/\/.*$/gm, '')
+        .replace(/\/\*[\s\S]*?\*\//g, '')
+        .trim();
+
+      // Check for `as *` pattern — with optional `with (...)` after
+      if (/\bas\s+\*\s*(?:with\s*\(|$)/i.test(cleaned)) {
+        utils.report({
+          message: messages.rejected,
+          node,
+          result,
+          ruleName,
+        });
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Description
- Adds `sass/at-use-no-unnamespaced` rule that disallows `@use ... as *` (wildcard namespace)
- Detects all variants: user modules, built-in modules (`sass:math`), and `with()` configuration
- Includes rule docs with Why?, Configuration, and BAD/GOOD examples
- Registered in plugin index and recommended config

## Test plan
- [x] `pnpm check` passes
- [x] 3 BAD cases: wildcard user module, wildcard built-in, wildcard with `with()` config
- [x] 6 GOOD cases: default namespace, explicit alias, built-in default/alias, `@forward`, multiple namespaced
- [x] Smoke test integration