### PR TITLE
Closes #12: add sass/selector-no-redundant-nesting-selector rule

### DIFF
--- a/docs/rules/selector-no-redundant-nesting-selector.md
+++ b/docs/rules/selector-no-redundant-nesting-selector.md
@@ -1,0 +1,121 @@
+# sass/selector-no-redundant-nesting-selector
+
+Disallow redundant nesting selectors (`&`) that don't add meaning. A lone `&` at the start of a
+selector that doesn't concatenate or use pseudo-classes/elements produces the same output as omitting
+it.
+
+**Default**: `true`
+**Fixable**: Yes (removes the redundant `&`)
+
+## Why?
+
+In Sass nesting, the parent selector `&` is implicitly prepended to nested selectors. Writing
+`& .child` inside `.parent` compiles to `.parent .child` -- exactly the same as just writing
+`.child`. The explicit `&` adds visual noise without changing the output.
+
+The `&` is only meaningful when it concatenates directly with another token (BEM modifiers like
+`&--primary`, pseudo-classes like `&:hover`, pseudo-elements like `&::before`, or compound selectors
+like `&.is-active`), or when it appears in a non-first position (`.parent &`).
+
+```sass
+// Redundant -- the & adds nothing
+.nav
+  & li
+    display: inline
+
+// Clean -- same compiled output
+.nav
+  li
+    display: inline
+```
+
+Removing redundant `&` selectors keeps stylesheets concise and easier to scan.
+
+## Configuration
+
+```json
+{
+  "sass/selector-no-redundant-nesting-selector": true
+}
+```
+
+## BAD
+
+```sass
+// Redundant & with descendant
+.parent
+  & .child
+    color: red
+```
+
+```sass
+// Redundant & with child combinator (space after &)
+.parent
+  & > .child
+    color: red
+```
+
+```sass
+// Redundant & before element selector
+.nav
+  & li
+    display: inline
+```
+
+## GOOD
+
+```sass
+// No & needed -- simple nesting
+.parent
+  .child
+    color: red
+```
+
+```sass
+// & for concatenation (BEM)
+.btn
+  &--primary
+    background: blue
+
+  &__icon
+    margin-right: 8px
+```
+
+```sass
+// & for pseudo-class
+.link
+  &:hover
+    text-decoration: underline
+
+  &:focus-visible
+    outline: 2px solid blue
+```
+
+```sass
+// & for pseudo-element
+.icon
+  &::before
+    content: ""
+    display: block
+```
+
+```sass
+// & in compound selector
+.card
+  &.is-active
+    border-color: blue
+```
+
+```sass
+// & after another selector (parent reference in non-first position)
+.child
+  .parent &
+    color: red
+```
+
+```sass
+// & at root of @at-root
+.component
+  @at-root #{&}-wrapper
+    display: block
+```

--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -72,3 +72,8 @@ $fontSize: 16px
 
 =dup-mixin
   padding: 0
+
+// sass/selector-no-redundant-nesting-selector
+.redundant-parent
+  & .redundant-child
+    color: red

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -57,6 +57,7 @@ describe('recommended config', () => {
         'sass/at-use-no-unnamespaced',
         'sass/no-duplicate-mixins',
         'sass/no-duplicate-load-rules',
+        'sass/selector-no-redundant-nesting-selector',
       ]),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ import declarationsBeforeNesting from './rules/declarations-before-nesting/index
 import atUseNoUnnamespaced from './rules/at-use-no-unnamespaced/index.js';
 import noDuplicateMixins from './rules/no-duplicate-mixins/index.js';
 import noDuplicateLoadRules from './rules/no-duplicate-load-rules/index.js';
+import selectorNoRedundantNestingSelector from './rules/selector-no-redundant-nesting-selector/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -42,6 +43,7 @@ const rules: stylelint.Plugin[] = [
   atUseNoUnnamespaced,
   noDuplicateMixins,
   noDuplicateLoadRules,
+  selectorNoRedundantNestingSelector,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -63,5 +63,6 @@ export default {
     'sass/at-use-no-unnamespaced': true,
     'sass/no-duplicate-mixins': true,
     'sass/no-duplicate-load-rules': true,
+    'sass/selector-no-redundant-nesting-selector': true,
   },
 };

--- a/src/rules/selector-no-redundant-nesting-selector/index.test.ts
+++ b/src/rules/selector-no-redundant-nesting-selector/index.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/selector-no-redundant-nesting-selector': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+/**
+ * Run lint with autofix and return the selectors from the fixed PostCSS root.
+ *
+ * Stylelint stringifies fixed output with the default CSS stringifier, so we
+ * walk the PostCSS root directly to inspect fixed selectors.
+ *
+ * @param code - Sass indented-syntax source
+ * @returns Array of selector strings from the fixed AST
+ */
+async function lintFix(code: string) {
+  const result = await stylelint.lint({ code, config, fix: true });
+  const selectors: string[] = [];
+  result.results[0]!._postcssResult!.root.walkRules((r: { selector: string }) => {
+    selectors.push(r.selector);
+  });
+  return selectors;
+}
+
+describe('sass/selector-no-redundant-nesting-selector', () => {
+  // BAD cases from spec
+
+  it('rejects redundant & with descendant selector', async () => {
+    const result = await lint('.parent\n  & .child\n    color: red');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/selector-no-redundant-nesting-selector');
+    const selectors = await lintFix('.parent\n  & .child\n    color: red');
+    expect(selectors).toContain('.child');
+    expect(selectors).not.toContainEqual(expect.stringMatching(/^&\s/));
+  });
+
+  it('rejects redundant & with child combinator', async () => {
+    const result = await lint('.parent\n  & > .child\n    color: red');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/selector-no-redundant-nesting-selector');
+    const selectors = await lintFix('.parent\n  & > .child\n    color: red');
+    expect(selectors).toContain('> .child');
+    expect(selectors).not.toContainEqual(expect.stringMatching(/^&\s/));
+  });
+
+  it('rejects redundant & before element selector', async () => {
+    const result = await lint('.nav\n  & li\n    display: inline');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/selector-no-redundant-nesting-selector');
+    const selectors = await lintFix('.nav\n  & li\n    display: inline');
+    expect(selectors).toContain('li');
+    expect(selectors).not.toContainEqual(expect.stringMatching(/^&\s/));
+  });
+
+  // GOOD cases from spec
+
+  it('accepts simple nesting without &', async () => {
+    const result = await lint('.parent\n  .child\n    color: red');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts & for BEM concatenation (modifier)', async () => {
+    const result = await lint('.btn\n  &--primary\n    background: blue');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts & for BEM concatenation (element)', async () => {
+    const result = await lint('.btn\n  &__icon\n    margin-right: 8px');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts & for pseudo-class :hover', async () => {
+    const result = await lint('.link\n  &:hover\n    text-decoration: underline');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts & for pseudo-class :focus-visible', async () => {
+    const result = await lint('.link\n  &:focus-visible\n    outline: 2px solid blue');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts & for pseudo-element ::before', async () => {
+    const result = await lint('.icon\n  &::before\n    content: ""\n    display: block');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts & in compound selector', async () => {
+    const result = await lint('.card\n  &.is-active\n    border-color: blue');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts & after another selector (non-first position)', async () => {
+    const result = await lint('.child\n  .parent &\n    color: red');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts & in @at-root interpolation', async () => {
+    const result = await lint('.component\n  @at-root #{&}-wrapper\n    display: block');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Edge cases
+
+  it('rejects redundant & with sibling combinator', async () => {
+    const result = await lint('.parent\n  & + .sibling\n    color: red');
+    expect(result.warnings).toHaveLength(1);
+    const selectors = await lintFix('.parent\n  & + .sibling\n    color: red');
+    expect(selectors).toContain('+ .sibling');
+    expect(selectors).not.toContainEqual(expect.stringMatching(/^&\s/));
+  });
+
+  it('rejects redundant & with general sibling combinator', async () => {
+    const result = await lint('.parent\n  & ~ .sibling\n    color: red');
+    expect(result.warnings).toHaveLength(1);
+    const selectors = await lintFix('.parent\n  & ~ .sibling\n    color: red');
+    expect(selectors).toContain('~ .sibling');
+    expect(selectors).not.toContainEqual(expect.stringMatching(/^&\s/));
+  });
+
+  it('reports multiple redundant & in same parent', async () => {
+    const result = await lint('.parent\n  & .child\n    color: red\n  & li\n    color: blue');
+    expect(result.warnings).toHaveLength(2);
+    const selectors = await lintFix('.parent\n  & .child\n    color: red\n  & li\n    color: blue');
+    expect(selectors).toContain('.child');
+    expect(selectors).toContain('li');
+    expect(selectors).not.toContainEqual(expect.stringMatching(/^&\s/));
+  });
+
+  it('detects and fixes redundant & with multiple spaces', async () => {
+    const result = await lint('.parent\n  &  .child\n    color: red');
+    expect(result.warnings).toHaveLength(1);
+    const selectors = await lintFix('.parent\n  &  .child\n    color: red');
+    expect(selectors).toContain('.child');
+    expect(selectors).not.toContainEqual(expect.stringMatching(/^&\s/));
+  });
+
+  it('accepts lone & (entire selector is just &)', async () => {
+    // A lone & by itself is a different pattern — it references the parent.
+    // This is typically used with @at-root or similar constructs.
+    // We do NOT flag it because it is syntactically valid and not redundant
+    // in the way described by the spec.
+    const result = await lint('.parent\n  &\n    color: red');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts selector list with & concatenation', async () => {
+    const result = await lint('.btn\n  &:hover, &:focus\n    outline: none');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('rejects redundant & in deeply nested rule', async () => {
+    const result = await lint('.a\n  .b\n    & .c\n      color: red');
+    expect(result.warnings).toHaveLength(1);
+    const selectors = await lintFix('.a\n  .b\n    & .c\n      color: red');
+    expect(selectors).toContain('.c');
+    expect(selectors).not.toContainEqual(expect.stringMatching(/^&\s/));
+  });
+});

--- a/src/rules/selector-no-redundant-nesting-selector/index.ts
+++ b/src/rules/selector-no-redundant-nesting-selector/index.ts
@@ -1,0 +1,139 @@
+/**
+ * Rule: `sass/selector-no-redundant-nesting-selector`
+ *
+ * Disallow redundant nesting selectors (`&`) that don't add meaning.
+ * A lone `&` at the start of a selector that doesn't concatenate or use
+ * pseudo-classes/elements produces the same output as omitting it.
+ *
+ * @example
+ * ```sass
+ * // BAD — redundant &
+ * .parent
+ *   & .child
+ *     color: red
+ *
+ * // GOOD — & omitted
+ * .parent
+ *   .child
+ *     color: red
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/selector-no-redundant-nesting-selector';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/selector-no-redundant-nesting-selector.md',
+  fixable: true,
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: 'Unexpected redundant nesting selector (&)',
+});
+
+/**
+ * Pattern that matches a redundant `&` at the start of a single selector.
+ *
+ * A nesting selector is redundant when it appears at the very beginning
+ * followed by whitespace (optionally with a combinator like `>`, `+`, `~`).
+ * This means it simply re-states the parent context without concatenation,
+ * pseudo-classes, pseudo-elements, or compound selectors.
+ *
+ * Examples that match (redundant):
+ * - `& .child`
+ * - `& > .child`
+ * - `& + .sibling`
+ * - `& ~ .general`
+ *
+ * Examples that do NOT match (meaningful):
+ * - `&--modifier` (BEM concatenation)
+ * - `&:hover` (pseudo-class)
+ * - `&::before` (pseudo-element)
+ * - `&.class` (compound)
+ * - `.parent &` (non-first position)
+ * - `&` (lone ampersand)
+ */
+const REDUNDANT_NESTING_RE = /^&\s+/;
+
+/**
+ * Check whether a single selector part has a redundant leading `&`.
+ *
+ * @param selector - A single (non-comma-separated) selector string, trimmed
+ * @returns `true` when the selector starts with a redundant `&`
+ */
+function isRedundant(selector: string): boolean {
+  return REDUNDANT_NESTING_RE.test(selector);
+}
+
+/**
+ * Stylelint rule function for `sass/selector-no-redundant-nesting-selector`.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback that walks rule nodes
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    root.walkRules((rule) => {
+      // Skip rules that aren't nested (top-level rules can't have &)
+      if (!rule.parent || rule.parent.type === 'root') return;
+
+      const selector = rule.selector;
+
+      // Split comma-separated selector list and check each part
+      const parts = selector.split(',');
+
+      for (const part of parts) {
+        const trimmed = part.trim();
+
+        if (isRedundant(trimmed)) {
+          utils.report({
+            message: messages.rejected,
+            node: rule,
+            result,
+            ruleName,
+            word: '&',
+            fix: {
+              apply: () => {
+                // Remove the redundant "& " from each matching part
+                rule.selector = parts
+                  .map((p) => {
+                    const t = p.trim();
+                    if (isRedundant(t)) {
+                      return p.replace(/&\s+/, '');
+                    }
+                    return p;
+                  })
+                  .join(',');
+              },
+              node: rule,
+            },
+          });
+          // Report once per rule node, even if multiple parts are redundant
+          break;
+        }
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Summary
- Add `sass/selector-no-redundant-nesting-selector` rule that disallows redundant `&` nesting selectors
- Detects `& .child`, `& > .child`, `& + .sibling`, `& ~ .general`, `& li` as redundant — the `&` adds no meaning when followed by whitespace
- Correctly allows meaningful `&` usage: BEM concatenation (`&--primary`, `&__icon`), pseudo-classes (`&:hover`), pseudo-elements (`&::before`), compound selectors (`&.is-active`), non-first position (`.parent &`), and `@at-root` interpolation (`#{&}`)
- Fixable: automatically removes the redundant `& ` prefix
- Register rule in plugin entry, recommended config, and smoke test

## Test plan
- [x] `pnpm check` passes (typecheck, lint, format, 241 tests)
- [x] BAD: `& .child` descendant → 1 warning + fix removes `& `
- [x] BAD: `& > .child` child combinator → 1 warning + fix
- [x] BAD: `& li` element selector → 1 warning + fix
- [x] GOOD: simple nesting, BEM, pseudo-class/element, compound, non-first `&`, `@at-root` → 0 warnings each
- [x] Edge cases: sibling/general sibling combinators, multiple warnings, multiple spaces, lone `&`, selector lists, deep nesting
- [x] Smoke test: `invalid.sass` triggers `sass/selector-no-redundant-nesting-selector`