### PR TITLE
Closes #16: add sass/no-duplicate-mixins rule

### DIFF
--- a/docs/rules/no-duplicate-mixins.md
+++ b/docs/rules/no-duplicate-mixins.md
@@ -1,0 +1,106 @@
+# sass/no-duplicate-mixins
+
+Disallow duplicate mixin definitions within the same scope.
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+In Sass, mixins are defined with `@mixin` (or the `=` shorthand in indented syntax). If you define
+two mixins with the same name in the same scope, the second silently overrides the first — Sass
+does not warn you:
+
+```sass
+=button
+  padding: 8px 16px
+  border: none
+
+// ...200 lines later...
+
+=button
+  padding: 12px 24px
+  border-radius: 4px
+```
+
+Now every `+button` call gets only the second definition. The first is completely lost, and there
+is no error or warning at compile time. This is especially dangerous in large codebases where
+mixins may be defined far apart.
+
+This rule catches duplicate mixin names within the same scope, regardless of whether they use
+`@mixin` or `=` syntax, and regardless of whether the parameter lists differ (Sass does not
+support mixin overloading — the last definition always wins).
+
+Note that the same mixin name in _different files_ is fine — Sass's module system (`@use`)
+namespaces them automatically.
+
+## Configuration
+
+```json
+{
+  "sass/no-duplicate-mixins": true
+}
+```
+
+## BAD
+
+```sass
+// Duplicate mixin at root scope
+=button
+  padding: 8px 16px
+  border: none
+
+=button
+  padding: 12px 24px
+  border-radius: 4px
+```
+
+```sass
+// Duplicate with = shorthand
+=reset
+  margin: 0
+
+=reset
+  margin: 0
+  padding: 0
+```
+
+```sass
+// Duplicate using @mixin syntax
+@mixin card
+  border: 1px solid #ccc
+
+@mixin card
+  border: 1px solid #ddd
+  border-radius: 8px
+```
+
+```sass
+// Duplicate with different parameters (still same name)
+=spacing($size)
+  padding: $size
+
+=spacing($size, $direction: all)
+  padding: $size
+```
+
+## GOOD
+
+```sass
+// Unique mixin names
+=button-base
+  padding: 8px 16px
+  border: none
+
+=button-primary
+  +button-base
+  background: blue
+  color: white
+```
+
+```sass
+// Single mixin definition
+@mixin respond-to($bp)
+  @media (min-width: $bp)
+    @content
+```

--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -63,3 +63,10 @@
 
 // sass/dollar-variable-pattern
 $fontSize: 16px
+
+// sass/no-duplicate-mixins
+=dup-mixin
+  margin: 0
+
+=dup-mixin
+  padding: 0

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -55,6 +55,7 @@ describe('recommended config', () => {
         'sass/no-warn',
         'sass/no-import',
         'sass/at-use-no-unnamespaced',
+        'sass/no-duplicate-mixins',
       ]),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import atUseNoRedundantAlias from './rules/at-use-no-redundant-alias/index.js';
 import atIfNoNull from './rules/at-if-no-null/index.js';
 import declarationsBeforeNesting from './rules/declarations-before-nesting/index.js';
 import atUseNoUnnamespaced from './rules/at-use-no-unnamespaced/index.js';
+import noDuplicateMixins from './rules/no-duplicate-mixins/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -38,6 +39,7 @@ const rules: stylelint.Plugin[] = [
   atIfNoNull,
   declarationsBeforeNesting,
   atUseNoUnnamespaced,
+  noDuplicateMixins,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -61,5 +61,6 @@ export default {
     'sass/at-if-no-null': true,
     'sass/declarations-before-nesting': true,
     'sass/at-use-no-unnamespaced': true,
+    'sass/no-duplicate-mixins': true,
   },
 };

--- a/src/rules/no-duplicate-mixins/index.test.ts
+++ b/src/rules/no-duplicate-mixins/index.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/no-duplicate-mixins': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/no-duplicate-mixins', () => {
+  // BAD cases — should report
+
+  it('rejects duplicate mixin at root scope (= shorthand)', async () => {
+    const code = '=button\n  padding: 8px 16px\n\n=button\n  padding: 12px 24px';
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-mixins');
+  });
+
+  it('rejects duplicate with = shorthand', async () => {
+    const code = '=reset\n  margin: 0\n\n=reset\n  margin: 0\n  padding: 0';
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-mixins');
+  });
+
+  it('rejects duplicate using @mixin syntax', async () => {
+    const code = '@mixin card\n  border: 1px solid #ccc\n\n@mixin card\n  border: 1px solid #ddd';
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-mixins');
+  });
+
+  it('rejects duplicate with different parameters', async () => {
+    const code =
+      '=spacing($size)\n  padding: $size\n\n=spacing($size, $direction: all)\n  padding: $size';
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-mixins');
+  });
+
+  // GOOD cases — should NOT report
+
+  it('accepts unique mixin names', async () => {
+    const code =
+      '=button-base\n  padding: 8px 16px\n\n=button-primary\n  +button-base\n  background: blue';
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts single mixin definition with @mixin', async () => {
+    const code = '@mixin respond-to($bp)\n  @media (min-width: $bp)\n    @content';
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/no-duplicate-mixins/index.ts
+++ b/src/rules/no-duplicate-mixins/index.ts
@@ -1,0 +1,114 @@
+/**
+ * Rule: `sass/no-duplicate-mixins`
+ *
+ * Disallow duplicate mixin definitions within the same scope. Duplicate
+ * definitions silently override the first, making behavior unpredictable.
+ *
+ * @example
+ * ```sass
+ * // BAD — duplicate mixin definition
+ * =button
+ *   padding: 8px 16px
+ *
+ * =button
+ *   padding: 12px 24px
+ *
+ * // GOOD — unique mixin names
+ * =button-base
+ *   padding: 8px 16px
+ *
+ * =button-primary
+ *   +button-base
+ *   background: blue
+ * ```
+ */
+import stylelint from 'stylelint';
+import type { ChildNode, Container } from 'postcss';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/no-duplicate-mixins';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/no-duplicate-mixins.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: (mixinName: string) => `Unexpected duplicate mixin definition '${mixinName}'`,
+});
+
+/**
+ * Extracts the mixin name from the at-rule params, stripping any arguments.
+ *
+ * @param params - The raw params string from the at-rule node
+ * @returns The mixin name without parenthesized arguments
+ *
+ * @example
+ * ```ts
+ * extractMixinName('spacing($size)')       // 'spacing'
+ * extractMixinName('button')              // 'button'
+ * extractMixinName('spacing($size, $dir)') // 'spacing'
+ * ```
+ */
+function extractMixinName(params: string): string {
+  const parenIndex = params.indexOf('(');
+  return parenIndex === -1 ? params.trim() : params.slice(0, parenIndex).trim();
+}
+
+/**
+ * Stylelint rule function for `sass/no-duplicate-mixins`.
+ *
+ * Walks `@mixin` at-rules and tracks seen mixin names per scope (parent node).
+ * Reports duplicates within the same scope.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    const scopeMap = new Map<Container<ChildNode> | undefined, Set<string>>();
+
+    root.walkAtRules('mixin', (node) => {
+      const name = extractMixinName(node.params);
+      if (!name) return;
+
+      const scope = node.parent;
+      let seen = scopeMap.get(scope);
+      if (!seen) {
+        seen = new Set<string>();
+        scopeMap.set(scope, seen);
+      }
+
+      if (seen.has(name)) {
+        utils.report({
+          message: messages.rejected(name),
+          node,
+          result,
+          ruleName,
+        });
+      } else {
+        seen.add(name);
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Summary
- Add `sass/no-duplicate-mixins` rule that disallows duplicate mixin definitions within the same scope
- Tracks mixin names per scope (parent node) — duplicates in different scopes are allowed
- Handles both `@mixin` and `=` shorthand syntax, and correctly ignores differing parameter lists (Sass does not support overloading)
- Register rule in plugin entry, recommended config, and smoke test

## Test plan
- [x] `pnpm check` passes (typecheck, lint, format, 210 tests)
- [x] BAD: duplicate `=button` at root scope → 1 warning
- [x] BAD: duplicate `=reset` shorthand → 1 warning
- [x] BAD: duplicate `@mixin card` → 1 warning
- [x] BAD: duplicate `=spacing` with different params → 1 warning
- [x] GOOD: unique mixin names → 0 warnings
- [x] GOOD: single `@mixin` definition → 0 warnings
- [x] Smoke test: `invalid.sass` triggers `sass/no-duplicate-mixins`