### PR TITLE
Closes #22: add sass/no-duplicate-dollar-variables rule

### DIFF
--- a/docs/rules/no-duplicate-dollar-variables.md
+++ b/docs/rules/no-duplicate-dollar-variables.md
@@ -1,0 +1,142 @@
+# sass/no-duplicate-dollar-variables
+
+Disallow duplicate `$variable` declarations within the same scope.
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+Sass variables declared with `$name: value` are mutable — if you declare the same variable twice
+in the same scope, the second silently overrides the first with no warning:
+
+```sass
+$spacing: 8px
+$primary: blue
+$spacing: 12px   // silently overrides the 8px above
+```
+
+This makes the final value of `$spacing` depend on which declaration the reader notices last, which
+is error-prone in large stylesheets. In most cases the duplicate is either a mistake (copy-paste
+artifact) or a sign that the variables should have different names.
+
+Note that Sass **scoping** means a variable declared inside a rule block is a _different_ variable
+from one with the same name at the root. This rule only flags duplicates within the **same** scope:
+
+```sass
+$color: red         // root scope
+
+.component
+  $color: blue      // different scope — no conflict
+  color: $color
+```
+
+### `!default` declarations
+
+The `!default` flag is a deliberate Sass pattern for providing fallback values that consumers can
+override. When `ignoreDefaults: true` is set, a `!default` declaration followed by a regular
+declaration is not flagged.
+
+## Configuration
+
+```json
+{
+  "sass/no-duplicate-dollar-variables": true
+}
+```
+
+### Options
+
+#### `ignoreDefaults: true`
+
+Ignore `$variable: value !default` declarations when checking for duplicates.
+
+```json
+{
+  "sass/no-duplicate-dollar-variables": [true, { "ignoreDefaults": true }]
+}
+```
+
+#### `ignoreInside: ["if-else"]`
+
+Ignore duplicate declarations inside `@if` / `@else` blocks (conditional assignment pattern).
+
+```json
+{
+  "sass/no-duplicate-dollar-variables": [true, { "ignoreInside": ["if-else"] }]
+}
+```
+
+#### `ignoreInside: ["at-rule"]`
+
+Ignore duplicate declarations inside any at-rule.
+
+```json
+{
+  "sass/no-duplicate-dollar-variables": [true, { "ignoreInside": ["at-rule"] }]
+}
+```
+
+## BAD
+
+```sass
+// Duplicate at root scope
+$color: red
+$color: blue
+```
+
+```sass
+// Duplicate inside same rule block
+.component
+  $size: 16px
+  $size: 20px
+  font-size: $size
+```
+
+```sass
+// Duplicate across declarations in same scope
+$spacing: 8px
+$primary: blue
+$spacing: 12px
+```
+
+## GOOD
+
+```sass
+// Unique variable names
+$spacing-sm: 4px
+$spacing-md: 8px
+$spacing-lg: 16px
+```
+
+```sass
+// Same name in different scopes
+$color: red
+
+.component
+  $color: blue
+  color: $color
+```
+
+```sass
+// Different variables
+$font-family: sans-serif
+$font-size: 16px
+$font-weight: 400
+```
+
+```sass
+// !default re-declaration (with ignoreDefaults: true)
+$primary: blue !default
+$primary: red
+```
+
+```sass
+// Conditional assignment (with ignoreInside: ["if-else"])
+$theme: light
+
+@if $theme == dark
+  $bg: #111
+@else
+  $bg: #fff
+```

--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -77,3 +77,7 @@ $fontSize: 16px
 .redundant-parent
   & .redundant-child
     color: red
+
+// sass/no-duplicate-dollar-variables
+$dupVar: red
+$dupVar: blue

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -58,6 +58,7 @@ describe('recommended config', () => {
         'sass/no-duplicate-mixins',
         'sass/no-duplicate-load-rules',
         'sass/selector-no-redundant-nesting-selector',
+        'sass/no-duplicate-dollar-variables',
       ]),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,6 +24,7 @@ import atUseNoUnnamespaced from './rules/at-use-no-unnamespaced/index.js';
 import noDuplicateMixins from './rules/no-duplicate-mixins/index.js';
 import noDuplicateLoadRules from './rules/no-duplicate-load-rules/index.js';
 import selectorNoRedundantNestingSelector from './rules/selector-no-redundant-nesting-selector/index.js';
+import noDuplicateDollarVariables from './rules/no-duplicate-dollar-variables/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -44,6 +45,7 @@ const rules: stylelint.Plugin[] = [
   noDuplicateMixins,
   noDuplicateLoadRules,
   selectorNoRedundantNestingSelector,
+  noDuplicateDollarVariables,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -64,5 +64,6 @@ export default {
     'sass/no-duplicate-mixins': true,
     'sass/no-duplicate-load-rules': true,
     'sass/selector-no-redundant-nesting-selector': true,
+    'sass/no-duplicate-dollar-variables': true,
   },
 };

--- a/src/rules/no-duplicate-dollar-variables/index.test.ts
+++ b/src/rules/no-duplicate-dollar-variables/index.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/no-duplicate-dollar-variables': true },
+};
+
+async function lint(code: string, overrides?: Record<string, unknown>) {
+  const result = await stylelint.lint({
+    code,
+    config: overrides ? { ...config, rules: { ...overrides } } : config,
+  });
+  return result.results[0]!;
+}
+
+describe('sass/no-duplicate-dollar-variables', () => {
+  // BAD cases — should report
+
+  it('rejects duplicate at root scope', async () => {
+    const result = await lint('$color: red\n$color: blue');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-dollar-variables');
+  });
+
+  it('rejects duplicate inside same rule block', async () => {
+    const result = await lint('.component\n  $size: 16px\n  $size: 20px\n  font-size: $size');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-dollar-variables');
+  });
+
+  it('rejects duplicate across declarations in same scope', async () => {
+    const result = await lint('$spacing: 8px\n$primary: blue\n$spacing: 12px');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-dollar-variables');
+  });
+
+  // GOOD cases — should NOT report
+
+  it('accepts unique variable names', async () => {
+    const result = await lint('$spacing-sm: 4px\n$spacing-md: 8px\n$spacing-lg: 16px');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts same name in different scopes', async () => {
+    const result = await lint('$color: red\n\n.component\n  $color: blue\n  color: $color');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts different variables', async () => {
+    const result = await lint('$font-family: sans-serif\n$font-size: 16px\n$font-weight: 400');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Options: ignoreDefaults
+
+  it('reports !default duplicate when ignoreDefaults is off', async () => {
+    const result = await lint('$primary: blue !default\n$primary: red');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  it('ignores !default with ignoreDefaults: true', async () => {
+    const result = await lint('$primary: blue !default\n$primary: red', {
+      'sass/no-duplicate-dollar-variables': [true, { ignoreDefaults: true }],
+    });
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Options: ignoreInside
+
+  it('ignores duplicates inside if-else with ignoreInside: ["if-else"]', async () => {
+    // $bg at root AND inside @if — would be a same-scope duplicate without ignoreInside
+    const code = ['$bg: white', '', '@if $theme == dark', '  $bg: #111', '  $bg: #222'].join('\n');
+    // Without the option, the two $bg inside @if would trigger a warning
+    const withoutOption = await lint(code);
+    expect(withoutOption.warnings).toHaveLength(1);
+    // With the option, duplicates inside if-else are ignored
+    const result = await lint(code, {
+      'sass/no-duplicate-dollar-variables': [true, { ignoreInside: ['if-else'] }],
+    });
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('ignores duplicates inside at-rule with ignoreInside: ["at-rule"]', async () => {
+    const code = ['@mixin theme($mode)', '  $bg: white', '  $bg: black'].join('\n');
+    // Without the option, duplicate $bg inside @mixin triggers a warning
+    const withoutOption = await lint(code);
+    expect(withoutOption.warnings).toHaveLength(1);
+    // With the option, duplicates inside any at-rule are ignored
+    const result = await lint(code, {
+      'sass/no-duplicate-dollar-variables': [true, { ignoreInside: ['at-rule'] }],
+    });
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('still reports root-scope duplicates with ignoreInside: ["if-else"]', async () => {
+    const code = [
+      '$var: 10px',
+      '@if true',
+      '  $inner-var: 20px',
+      '  $inner-var: 30px',
+      '$var: 50px',
+    ].join('\n');
+    const result = await lint(code, {
+      'sass/no-duplicate-dollar-variables': [true, { ignoreInside: ['if-else'] }],
+    });
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]!.text).toContain("'$var'");
+  });
+
+  it('still reports root-scope duplicates with ignoreInside: ["at-rule"]', async () => {
+    const code = [
+      '$var: 10px',
+      '@mixin test',
+      '  $inner-var: 20px',
+      '  $inner-var: 30px',
+      '$var: 50px',
+    ].join('\n');
+    const result = await lint(code, {
+      'sass/no-duplicate-dollar-variables': [true, { ignoreInside: ['at-rule'] }],
+    });
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]!.text).toContain("'$var'");
+  });
+
+  it('ignores both if-else and at-rule with ignoreInside: ["if-else", "at-rule"]', async () => {
+    const code = [
+      '$root: 1px',
+      '@mixin theme',
+      '  $mixin-var: 2px',
+      '  $mixin-var: 3px',
+      '@if true',
+      '  $if-var: 4px',
+      '  $if-var: 5px',
+      '$root: 6px',
+    ].join('\n');
+    const result = await lint(code, {
+      'sass/no-duplicate-dollar-variables': [true, { ignoreInside: ['if-else', 'at-rule'] }],
+    });
+    // Only $root duplicate at root scope should be reported
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0]!.text).toContain("'$root'");
+  });
+});

--- a/src/rules/no-duplicate-dollar-variables/index.ts
+++ b/src/rules/no-duplicate-dollar-variables/index.ts
@@ -1,0 +1,168 @@
+/**
+ * Rule: `sass/no-duplicate-dollar-variables`
+ *
+ * Disallow duplicate `$variable` declarations within the same scope.
+ * Duplicate declarations silently override earlier values, making
+ * the final value unpredictable and the code confusing.
+ *
+ * @example
+ * ```sass
+ * // BAD — $color declared twice in the same scope
+ * $color: red
+ * $color: blue
+ *
+ * // GOOD — unique variable names
+ * $color-primary: red
+ * $color-secondary: blue
+ * ```
+ */
+import stylelint from 'stylelint';
+import type { AtRule, ChildNode, Container, Declaration } from 'postcss';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/no-duplicate-dollar-variables';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/no-duplicate-dollar-variables.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: (variable: string) => `Unexpected duplicate variable declaration '${variable}'`,
+});
+
+/**
+ * Checks whether a declaration node represents a `!default` variable.
+ *
+ * @param node - The PostCSS `Declaration` node
+ * @returns `true` if the value ends with `!default`
+ */
+function isDefaultDeclaration(node: Declaration): boolean {
+  // sass-parser's Declaration.important is not yet implemented (throws),
+  // so we check the raw source text for !default instead
+  if (node.source?.start && node.source?.end) {
+    const raw = node.source.input.css.slice(node.source.start.offset, node.source.end.offset + 1);
+    return raw.includes('!default');
+  }
+  const value = node.value ?? '';
+  return value.trim().endsWith('!default');
+}
+
+/**
+ * Checks whether a node is inside an `@if` / `@else` chain.
+ *
+ * @param node - The PostCSS node to check
+ * @returns `true` if the node is inside an `@if` or `@else` at-rule
+ */
+function isInsideIfElse(node: ChildNode): boolean {
+  let parent = node.parent;
+  while (parent && parent.type !== 'root') {
+    if (parent.type === 'atrule') {
+      const name = (parent as AtRule).name;
+      if (name === 'if' || name === 'else') return true;
+    }
+    parent = (parent as ChildNode).parent;
+  }
+  return false;
+}
+
+/**
+ * Checks whether a node is inside any at-rule.
+ *
+ * @param node - The PostCSS node to check
+ * @returns `true` if the node is inside an at-rule
+ */
+function isInsideAtRule(node: ChildNode): boolean {
+  let parent = node.parent;
+  while (parent && parent.type !== 'root') {
+    if (parent.type === 'atrule') return true;
+    parent = (parent as ChildNode).parent;
+  }
+  return false;
+}
+
+interface SecondaryOptions {
+  ignoreDefaults?: boolean;
+  ignoreInside?: string[];
+}
+
+/**
+ * Stylelint rule function for `sass/no-duplicate-dollar-variables`.
+ *
+ * Walks all declarations starting with `$` and tracks seen variable names
+ * per scope (parent node). Reports duplicates within the same scope.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @param secondaryOptions - Optional secondary options
+ * @returns A PostCSS plugin callback
+ */
+const ruleFunction: stylelint.Rule = (primary, secondaryOptions) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(
+      result,
+      ruleName,
+      { actual: primary },
+      {
+        actual: secondaryOptions,
+        possible: {
+          ignoreDefaults: [true, false],
+          ignoreInside: ['at-rule', 'if-else'],
+        },
+        optional: true,
+      },
+    );
+    if (!validOptions) return;
+
+    const opts = (secondaryOptions ?? {}) as SecondaryOptions;
+    const ignoreDefaults = opts.ignoreDefaults === true;
+    const ignoreInside = opts.ignoreInside ?? [];
+
+    // Track seen variable names per scope (using parent node identity)
+    const scopeMap = new Map<Container | undefined, Set<string>>();
+
+    root.walkDecls((decl) => {
+      const prop = decl.prop;
+      if (!prop.startsWith('$')) return;
+
+      // Check ignoreInside options
+      if (ignoreInside.includes('if-else') && isInsideIfElse(decl)) return;
+      if (ignoreInside.includes('at-rule') && isInsideAtRule(decl)) return;
+
+      // Check ignoreDefaults
+      if (ignoreDefaults && isDefaultDeclaration(decl)) return;
+
+      const scope = decl.parent;
+      let seen = scopeMap.get(scope);
+      if (!seen) {
+        seen = new Set<string>();
+        scopeMap.set(scope, seen);
+      }
+
+      if (seen.has(prop)) {
+        utils.report({
+          message: messages.rejected(prop),
+          node: decl,
+          result,
+          ruleName,
+        });
+      } else {
+        seen.add(prop);
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Description

Add `sass/no-duplicate-dollar-variables` rule that disallows duplicate `$variable` declarations within the same scope. Sass variables are mutable and duplicate declarations silently override previous values, making code error-prone in large stylesheets.

### Key Features

- Per-scope tracking via parent node identity — same variable name in different scopes is allowed
- Supports `ignoreDefaults: true` option to allow `!default` re-declarations (common config pattern)
- Supports `ignoreInside: ["if-else", "at-rule"]` to skip duplicates inside conditional or at-rule blocks
- Uses raw source text to detect `!default` flag (workaround for sass-parser's unimplemented `Declaration.important`)
- Register rule in plugin entry, recommended config, and smoke test

### Examples

**BAD:**
```sass
$color: red
$color: blue  // silently overrides red
```

**GOOD:**
```sass
$color: red

.component
  $color: blue  // different scope, no conflict
  color: $color
```

## Test Coverage

- [x] `pnpm check` passes (typecheck, lint, format, 251 tests)
- [x] BAD: duplicate `$color` at root → 1 warning
- [x] BAD: duplicate `$size` inside same rule block → 1 warning  
- [x] BAD: duplicate `$spacing` across declarations → 1 warning
- [x] GOOD: unique variable names → 0 warnings
- [x] GOOD: same name in different scopes → 0 warnings
- [x] GOOD: different variables → 0 warnings
- [x] Options: `ignoreDefaults: true` skips `!default` variables
- [x] Options: `ignoreInside: ["if-else"]` skips if/else blocks
- [x] Options: `ignoreInside: ["at-rule"]` skips all at-rules
- [x] Smoke test: `invalid.sass` triggers `sass/no-duplicate-dollar-variables`