### PR TITLE
Closes #25: add sass/no-duplicate-load-rules rule

### DIFF
--- a/docs/rules/no-duplicate-load-rules.md
+++ b/docs/rules/no-duplicate-load-rules.md
@@ -1,0 +1,119 @@
+# sass/no-duplicate-load-rules
+
+Disallow duplicate `@use`, `@forward`, or `@import` statements that load the same module.
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+Sass's `@use` and `@forward` rules load modules into the current file. Loading the same module
+twice serves no purpose — the second load is silently ignored by Sass, but it clutters the file
+and can confuse readers about where members come from:
+
+```sass
+@use "variables"
+@use "mixins"
+@use "variables"   // duplicate — silently ignored
+```
+
+For `@import` (the legacy loading mechanism), duplicate loads are even more harmful: Sass
+re-evaluates the file each time, potentially causing duplicate CSS output and unexpected side
+effects from re-executed `@if` guards or variable re-assignments.
+
+This rule flags any `@use`, `@forward`, or `@import` that loads a module already loaded by the
+same directive type in the same file. It normalizes file extensions (`.sass`, `.scss`, `.css`)
+so that `@use "variables"` and `@use "variables.sass"` are treated as duplicates.
+
+Note that `@use` and `@forward` of the same module are **not** considered duplicates — they serve
+different purposes (consuming vs re-exporting).
+
+## Configuration
+
+```json
+{
+  "sass/no-duplicate-load-rules": true
+}
+```
+
+## BAD
+
+```sass
+// Duplicate @use of the same module
+@use "variables"
+@use "mixins"
+@use "variables"
+```
+
+```sass
+// Duplicate @forward of the same module
+@forward "colors"
+@forward "typography"
+@forward "colors"
+```
+
+```sass
+// Duplicate @import of the same file
+@import "legacy/helpers"
+@import "legacy/grid"
+@import "legacy/helpers"
+```
+
+```sass
+// Same module with different aliases is still a duplicate load
+@use "colors" as c
+@use "colors" as clr
+```
+
+```sass
+// Same module with and without file extension
+@use "variables"
+@use "variables.sass"
+```
+
+```sass
+// Duplicate built-in module load
+@use "sass:math"
+@use "sass:color"
+@use "sass:math"
+```
+
+## GOOD
+
+```sass
+// Different modules loaded once each
+@use "sass:math"
+@use "sass:color"
+@use "variables"
+@use "mixins"
+```
+
+```sass
+// @use and @forward of the same module — different purposes
+@use "colors" as c
+@forward "colors"
+```
+
+```sass
+// Same filename in different directories — distinct modules
+@use "base/reset"
+@use "utils/reset"
+```
+
+```sass
+// Multiple distinct @use statements
+@use "sass:math"
+@use "variables" as vars
+@use "mixins" as mx
+@use "config"
+```
+
+```sass
+// @use with with() configuration
+// NOTE: even if a bare @use of the same module exists in another
+// file, a with() clause makes the load unique to this entry point.
+// However, two @use of the same module in the SAME file — one bare
+// and one with with() — is still flagged because Sass itself errors
+// on that.
+@use "config" with ($primary: #036, $border-radius: 4px)
+```

--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -59,6 +59,8 @@
 @warn "should not ship"
 
 // sass/no-import
+// sass/no-duplicate-load-rules (duplicate @import)
+@import "should-use-use-instead"
 @import "should-use-use-instead"
 
 // sass/dollar-variable-pattern

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -56,6 +56,7 @@ describe('recommended config', () => {
         'sass/no-import',
         'sass/at-use-no-unnamespaced',
         'sass/no-duplicate-mixins',
+        'sass/no-duplicate-load-rules',
       ]),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import atIfNoNull from './rules/at-if-no-null/index.js';
 import declarationsBeforeNesting from './rules/declarations-before-nesting/index.js';
 import atUseNoUnnamespaced from './rules/at-use-no-unnamespaced/index.js';
 import noDuplicateMixins from './rules/no-duplicate-mixins/index.js';
+import noDuplicateLoadRules from './rules/no-duplicate-load-rules/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -40,6 +41,7 @@ const rules: stylelint.Plugin[] = [
   declarationsBeforeNesting,
   atUseNoUnnamespaced,
   noDuplicateMixins,
+  noDuplicateLoadRules,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -62,5 +62,6 @@ export default {
     'sass/declarations-before-nesting': true,
     'sass/at-use-no-unnamespaced': true,
     'sass/no-duplicate-mixins': true,
+    'sass/no-duplicate-load-rules': true,
   },
 };

--- a/src/rules/no-duplicate-load-rules/index.test.ts
+++ b/src/rules/no-duplicate-load-rules/index.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/no-duplicate-load-rules': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/no-duplicate-load-rules', () => {
+  // BAD cases — should report
+
+  it('rejects duplicate @use of the same module', async () => {
+    const result = await lint('@use "variables"\n@use "mixins"\n@use "variables"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-load-rules');
+  });
+
+  it('rejects duplicate @forward of the same module', async () => {
+    const result = await lint('@forward "colors"\n@forward "typography"\n@forward "colors"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-load-rules');
+  });
+
+  it('rejects same module with different aliases', async () => {
+    const result = await lint('@use "colors" as c\n@use "colors" as clr');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-load-rules');
+  });
+
+  it('rejects duplicate built-in module load', async () => {
+    const result = await lint('@use "sass:math"\n@use "sass:color"\n@use "sass:math"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-load-rules');
+  });
+
+  it('rejects duplicate @import of the same file', async () => {
+    const result = await lint(
+      '@import "legacy/helpers"\n@import "legacy/grid"\n@import "legacy/helpers"',
+    );
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-load-rules');
+  });
+
+  it('rejects same module with and without file extension', async () => {
+    const result = await lint('@use "variables"\n@use "variables.sass"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-load-rules');
+  });
+
+  it('rejects bare @use and @use with with() of the same module', async () => {
+    const result = await lint('@use "config"\n@use "config" with ($primary: #036)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-duplicate-load-rules');
+  });
+
+  // GOOD cases — should NOT report
+
+  it('accepts different modules loaded once each', async () => {
+    const result = await lint(
+      '@use "sass:math"\n@use "sass:color"\n@use "variables"\n@use "mixins"',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @use and @forward of the same module', async () => {
+    const result = await lint('@use "colors" as c\n@forward "colors"');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts same filename in different directories', async () => {
+    const result = await lint('@use "base/reset"\n@use "utils/reset"');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts multiple distinct @use statements', async () => {
+    const code = [
+      '@use "sass:math"',
+      '@use "variables" as vars',
+      '@use "mixins" as mx',
+      '@use "config"',
+    ].join('\n');
+    const result = await lint(code);
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts @use with with() configuration', async () => {
+    const result = await lint('@use "config" with ($primary: #036, $border-radius: 4px)');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/no-duplicate-load-rules/index.ts
+++ b/src/rules/no-duplicate-load-rules/index.ts
@@ -1,0 +1,126 @@
+/**
+ * Rule: `sass/no-duplicate-load-rules`
+ *
+ * Disallow duplicate `@use`, `@forward`, or `@import` statements that load
+ * the same module. Duplicate loads are wasteful and can cause confusion
+ * about where members come from.
+ *
+ * @example
+ * ```sass
+ * // BAD — duplicate @use
+ * @use "variables"
+ * @use "mixins"
+ * @use "variables"
+ *
+ * // GOOD — each module loaded once
+ * @use "variables"
+ * @use "mixins"
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/no-duplicate-load-rules';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/no-duplicate-load-rules.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: (atRuleName: string, url: string) => `Unexpected duplicate @${atRuleName} of '${url}'`,
+});
+
+/** Load directive names this rule inspects. */
+const LOAD_DIRECTIVES = new Set(['use', 'forward', 'import']);
+
+/**
+ * Extracts the URL string from at-rule params.
+ *
+ * @param params - The raw params string from the at-rule node
+ * @returns The unquoted URL, or `null` if extraction fails
+ *
+ * @example
+ * ```ts
+ * extractUrl('"variables"')              // 'variables'
+ * extractUrl('"colors" as c')            // 'colors'
+ * extractUrl('"config" with ($a: 1)')    // 'config'
+ * ```
+ */
+function extractUrl(params: string): string | null {
+  const match = params.match(/['"]([^'"]+)['"]/);
+  return match ? match[1]! : null;
+}
+
+/**
+ * Normalizes a URL for comparison by stripping file extensions.
+ *
+ * @param url - The raw URL string
+ * @returns The normalized URL
+ */
+function normalizeUrl(url: string): string {
+  return url.replace(/\.(sass|scss|css)$/, '');
+}
+
+/**
+ * Stylelint rule function for `sass/no-duplicate-load-rules`.
+ *
+ * Walks `@use`, `@forward`, and `@import` at-rules and tracks seen URLs
+ * per directive type. Reports duplicates within the same directive type.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    // Track seen URLs per directive type
+    const seen = new Map<string, Set<string>>();
+
+    root.walkAtRules((node) => {
+      if (!LOAD_DIRECTIVES.has(node.name)) return;
+
+      const url = extractUrl(node.params);
+      if (!url) return;
+
+      const normalized = normalizeUrl(url);
+      const key = node.name;
+
+      let seenUrls = seen.get(key);
+      if (!seenUrls) {
+        seenUrls = new Set<string>();
+        seen.set(key, seenUrls);
+      }
+
+      if (seenUrls.has(normalized)) {
+        utils.report({
+          message: messages.rejected(node.name, url),
+          node,
+          result,
+          ruleName,
+        });
+      } else {
+        seenUrls.add(normalized);
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Summary
- Add `sass/no-duplicate-load-rules` rule that disallows duplicate `@use`, `@forward`, or `@import` statements loading the same module
- Tracks seen URLs per directive type — `@use` and `@forward` of the same module are allowed (different purposes)
- Normalizes file extensions (`.sass`, `.scss`, `.css`) so `@use "variables"` and `@use "variables.sass"` are treated as duplicates
- Handles aliases (`as`) and `with()` configuration — different aliases still flag as duplicate, `with()` is stripped during URL extraction
- Register rule in plugin entry, recommended config, and smoke test

## Test plan
- [x] `pnpm check` passes (typecheck, lint, format, 221 tests)
- [x] BAD: duplicate `@use "variables"` → 1 warning
- [x] BAD: duplicate `@forward "colors"` → 1 warning
- [x] BAD: duplicate `@import "legacy/helpers"` → 1 warning
- [x] BAD: same module with different aliases → 1 warning
- [x] BAD: with/without file extension → 1 warning
- [x] BAD: duplicate built-in module `sass:math` → 1 warning
- [x] GOOD: different modules → 0 warnings
- [x] GOOD: @use + @forward of same module → 0 warnings
- [x] GOOD: same filename in different directories → 0 warnings
- [x] GOOD: multiple distinct @use → 0 warnings
- [x] GOOD: @use with with() config → 0 warnings
- [x] Smoke test: `invalid.sass` triggers `sass/no-duplicate-load-rules`