### PR TITLE
Closes #19: add sass/no-color-literals rule

### DIFF
--- a/docs/rules/no-color-literals.md
+++ b/docs/rules/no-color-literals.md
@@ -1,0 +1,151 @@
+# sass/no-color-literals
+
+Disallow color literals (hex, named colors, rgb/hsl) used directly in property declarations. Colors
+should be stored in variables.
+
+**Default**: `"warning"`
+**Fixable**: No
+
+## Why?
+
+Hard-coded color values scattered across stylesheets make themes difficult to maintain. When a brand
+color changes, you must hunt through every file for every occurrence of `#336699` or `red`. If
+colors are stored in variables (or a design-token map), a single change propagates everywhere:
+
+```sass
+// Hard-coded — change requires find-and-replace across the whole project
+.header
+  background: #336699
+
+// Variable — one change updates every usage
+$primary: #336699
+.header
+  background: $primary
+```
+
+This rule flags color literals in property declarations so they are caught during linting. Variable
+assignments are allowed by default (`allowInVariables: true`), since that is where design tokens are
+defined.
+
+## Configuration
+
+```json
+{
+  "sass/no-color-literals": true
+}
+```
+
+With options:
+
+```json
+{
+  "sass/no-color-literals": [
+    true,
+    {
+      "allowInVariables": true,
+      "allowInFunctions": false,
+      "allowedColors": ["transparent", "currentColor", "inherit"]
+    }
+  ]
+}
+```
+
+### Options
+
+- **`allowInVariables`** (`boolean`, default: `true`) --
+  Allow color literals in `$variable` assignments.
+- **`allowInFunctions`** (`boolean`, default: `false`) --
+  Allow color literals as function arguments.
+- **`allowedColors`** (`string[]`,
+  default: `["transparent", "currentColor", "inherit"]`) --
+  Colors exempt from the rule.
+
+## BAD
+
+```sass
+// hex color in property declaration
+.header
+  background: #336699
+```
+
+```sass
+// named color in property
+.error
+  color: red
+```
+
+```sass
+// short hex color
+.link
+  color: #036
+```
+
+```sass
+// rgb() function
+.overlay
+  background: rgb(0, 0, 0)
+```
+
+```sass
+// hsl() function
+.accent
+  color: hsl(210, 100%, 50%)
+```
+
+```sass
+// rgba() function
+.modal-backdrop
+  background: rgba(0, 0, 0, 0.5)
+```
+
+```sass
+// color in shorthand property
+.card
+  border: 1px solid #ccc
+```
+
+## GOOD
+
+```sass
+// variable reference instead of literal
+$primary: #036
+
+.link
+  color: $primary
+```
+
+```sass
+// color literals in variable assignments (allowInVariables: true)
+$error-color: red
+$primary: #336699
+$overlay-bg: rgba(0, 0, 0, 0.5)
+```
+
+```sass
+// allowed colors (transparent, currentColor, inherit)
+.hidden
+  color: transparent
+
+.icon
+  fill: currentColor
+
+.reset
+  color: inherit
+```
+
+```sass
+// namespaced function with variables
+@use "sass:color"
+$primary: #036
+
+.adjusted
+  color: color.adjust($primary, $lightness: -10%)
+```
+
+```sass
+// design token map — colors in variable assignment
+$colors: (primary: #036, error: red, success: green)
+
+.link
+  color: map-get($colors, error)
+```

--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -68,6 +68,10 @@
   &-item
     display: inline-block
 
+// sass/no-color-literals
+.color-literal
+  background: #336699
+
 // sass/dollar-variable-pattern
 $fontSize: 16px
 

--- a/src/__tests__/fixtures/valid.sass
+++ b/src/__tests__/fixtures/valid.sass
@@ -1,12 +1,16 @@
+$white: #fff
+$dark: #333
+$link-color: #0af
+
 .button
-  color: #fff
-  background: #333
+  color: $white
+  background: $dark
   margin: 1em
   padding: 1em 2em
 
 .link
   text-decoration: none
-  color: #0af
+  color: $link-color
 
 nav
   ul

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -61,6 +61,7 @@ describe('recommended config', () => {
         'sass/no-duplicate-dollar-variables',
         'sass/selector-no-union-class-name',
         'sass/dimension-no-non-numeric-values',
+        'sass/no-color-literals',
       ]),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import selectorNoRedundantNestingSelector from './rules/selector-no-redundant-ne
 import noDuplicateDollarVariables from './rules/no-duplicate-dollar-variables/index.js';
 import selectorNoUnionClassName from './rules/selector-no-union-class-name/index.js';
 import dimensionNoNonNumericValues from './rules/dimension-no-non-numeric-values/index.js';
+import noColorLiterals from './rules/no-color-literals/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -50,6 +51,7 @@ const rules: stylelint.Plugin[] = [
   noDuplicateDollarVariables,
   selectorNoUnionClassName,
   dimensionNoNonNumericValues,
+  noColorLiterals,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -67,5 +67,6 @@ export default {
     'sass/no-duplicate-dollar-variables': true,
     'sass/selector-no-union-class-name': true,
     'sass/dimension-no-non-numeric-values': true,
+    'sass/no-color-literals': true,
   },
 };

--- a/src/rules/no-color-literals/index.test.ts
+++ b/src/rules/no-color-literals/index.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const defaultConfig = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/no-color-literals': true },
+};
+
+async function lint(code: string, options?: Record<string, unknown>) {
+  const config = options
+    ? {
+        ...defaultConfig,
+        rules: { 'sass/no-color-literals': [true, options] },
+      }
+    : defaultConfig;
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/no-color-literals', () => {
+  // BAD cases from spec
+
+  it('rejects hex color in property declaration', async () => {
+    const result = await lint('.header\n  background: #336699');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-color-literals');
+  });
+
+  it('rejects named color in property declaration', async () => {
+    const result = await lint('.error\n  color: red');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-color-literals');
+  });
+
+  it('rejects short hex color in property declaration', async () => {
+    const result = await lint('.link\n  color: #036');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-color-literals');
+  });
+
+  it('rejects rgb() in property declaration', async () => {
+    const result = await lint('.overlay\n  background: rgb(0, 0, 0)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-color-literals');
+  });
+
+  it('rejects hsl() in property declaration', async () => {
+    const result = await lint('.accent\n  color: hsl(210, 100%, 50%)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-color-literals');
+  });
+
+  it('rejects rgba() in property declaration', async () => {
+    const result = await lint('.modal-backdrop\n  background: rgba(0, 0, 0, 0.5)');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-color-literals');
+  });
+
+  it('rejects color in shorthand property', async () => {
+    const result = await lint('.card\n  border: 1px solid #ccc');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/no-color-literals');
+  });
+
+  // GOOD cases from spec
+
+  it('accepts variable reference instead of color literal', async () => {
+    const result = await lint('$primary: #036\n\n.link\n  color: $primary');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts color literals in variable assignments (allowInVariables default)', async () => {
+    const result = await lint(
+      '$error-color: red\n$primary: #336699\n$overlay-bg: rgba(0, 0, 0, 0.5)',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts allowed colors (transparent, currentColor, inherit)', async () => {
+    const result = await lint(
+      '.hidden\n  color: transparent\n\n.icon\n  fill: currentColor\n\n.reset\n  color: inherit',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts namespaced function calls with variable arguments', async () => {
+    const result = await lint(
+      '@use "sass:color"\n$primary: #036\n\n.adjusted\n  color: color.adjust($primary, $lightness: -10%)',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts design token map with colors in variable assignment', async () => {
+    const result = await lint(
+      '$colors: (primary: #036, error: red, success: green)\n\n.link\n  color: map-get($colors, error)',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Option: allowInVariables: false
+
+  it('rejects color in variable assignment when allowInVariables is false', async () => {
+    const result = await lint('$primary: #036', { allowInVariables: false });
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  // Option: allowInFunctions: true
+
+  it('accepts color literal in function argument when allowInFunctions is true', async () => {
+    const result = await lint('.box\n  background: rgba(0, 0, 0, 0.5)', {
+      allowInFunctions: true,
+    });
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('rejects color literal in function argument by default', async () => {
+    const result = await lint('.box\n  background: rgba(0, 0, 0, 0.5)');
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  // Option: allowedColors
+
+  it('accepts custom allowed colors', async () => {
+    const result = await lint('.box\n  background: white', {
+      allowedColors: ['transparent', 'currentColor', 'inherit', 'white'],
+    });
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('rejects colors not in allowedColors list', async () => {
+    const result = await lint('.box\n  color: red', {
+      allowedColors: ['transparent'],
+    });
+    expect(result.warnings).toHaveLength(1);
+  });
+
+  // Edge cases
+
+  it('reports multiple violations in a single rule', async () => {
+    const result = await lint('.box\n  color: red\n  background: blue');
+    expect(result.warnings).toHaveLength(2);
+  });
+
+  it('does not flag non-color values', async () => {
+    const result = await lint('.box\n  width: 100px\n  display: block\n  margin: 1em auto');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('does not flag color in comment', async () => {
+    const result = await lint('// color: red\n.box\n  width: 100px');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/no-color-literals/index.ts
+++ b/src/rules/no-color-literals/index.ts
@@ -1,0 +1,246 @@
+/**
+ * Rule: `sass/no-color-literals`
+ *
+ * Disallow color literals (hex, named colors, rgb/hsl) used directly in
+ * property declarations. Colors should be stored in variables.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule
+ * .header
+ *   background: #336699
+ *
+ * // GOOD — use a variable
+ * $primary: #336699
+ * .header
+ *   background: $primary
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/no-color-literals';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/no-color-literals.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ *
+ * @param color - The color literal that was found
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: (color: string) => `Unexpected color literal "${color}". Use a variable instead`,
+});
+
+/**
+ * Default colors that are exempt from the rule.
+ * These are CSS keywords that are commonly used as non-design-token values.
+ * Stored in lowercase for case-insensitive matching.
+ */
+const DEFAULT_ALLOWED_COLORS = ['transparent', 'currentcolor', 'inherit'];
+
+/**
+ * CSS color function names that produce color values.
+ */
+const COLOR_FUNCTION_NAMES = new Set(['rgb', 'rgba', 'hsl', 'hsla']);
+
+/**
+ * Get the original source text of a color expression node.
+ *
+ * sass-parser normalizes named colors (e.g. `red` to `#ff0000`) and short hex
+ * (e.g. `#036` to `#003366`). This function retrieves the original text from
+ * the source span when available, falling back to the normalized string
+ * representation.
+ *
+ * @param expr - A sass-parser expression node with sassType 'color'
+ * @returns The original source text of the color, or the normalized string
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function getOriginalColorText(expr: any): string {
+  // Access the internal SassColor value's format span to get original source text
+  const format = expr?._value?.format;
+  if (format?._color0$_span?.text) {
+    return format._color0$_span.text as string;
+  }
+  // Fall back to the normalized string representation
+  return String(expr);
+}
+
+/**
+ * Check if a color's original text is in the allowed colors list.
+ *
+ * @param originalText - The original source text of the color
+ * @param allowedColors - Set of allowed color names (lowercase)
+ * @returns `true` if the color is allowed
+ */
+function isAllowedColor(originalText: string, allowedColors: Set<string>): boolean {
+  return allowedColors.has(originalText.toLowerCase());
+}
+
+/**
+ * Collect color literals from a sass-parser expression node.
+ *
+ * Recursively walks the expression tree to find color literals and
+ * color function calls. Respects the `allowInFunctions` and
+ * `allowedColors` options.
+ *
+ * @param expr - A sass-parser expression node
+ * @param allowInFunctions - Whether to allow color literals inside function calls
+ * @param allowedColors - Set of allowed color names (lowercase)
+ * @param insideFunctionArg - Whether we are currently inside a function argument
+ * @returns Array of original color literal text strings that violate the rule
+ */
+function collectColorLiterals(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  expr: any,
+  allowInFunctions: boolean,
+  allowedColors: Set<string>,
+  insideFunctionArg = false,
+): string[] {
+  if (!expr || !expr.sassType) return [];
+
+  const colors: string[] = [];
+
+  switch (expr.sassType) {
+    case 'color': {
+      if (insideFunctionArg && allowInFunctions) break;
+      const originalText = getOriginalColorText(expr);
+      if (!isAllowedColor(originalText, allowedColors)) {
+        colors.push(originalText);
+      }
+      break;
+    }
+
+    case 'function-call': {
+      const funcName = expr._name ? String(expr._name) : '';
+      if (COLOR_FUNCTION_NAMES.has(funcName.toLowerCase())) {
+        // This is a color function like rgb(), rgba(), hsl(), hsla()
+        if (!allowInFunctions) {
+          // Report the whole function call as a color literal
+          colors.push(String(expr));
+        }
+      } else {
+        // Non-color function — check arguments for color literals
+        if (expr._arguments?._nodes) {
+          for (const arg of expr._arguments._nodes) {
+            // Each argument node wraps an expression
+            const argExpr = arg?._expression;
+            if (argExpr) {
+              colors.push(...collectColorLiterals(argExpr, allowInFunctions, allowedColors, true));
+            }
+          }
+        }
+      }
+      break;
+    }
+
+    case 'list': {
+      if (expr._nodes) {
+        for (const child of expr._nodes) {
+          colors.push(
+            ...collectColorLiterals(child, allowInFunctions, allowedColors, insideFunctionArg),
+          );
+        }
+      }
+      break;
+    }
+
+    // 'variable', 'string', 'number', 'map', etc. — not color literals
+    default:
+      break;
+  }
+
+  return colors;
+}
+
+/** Secondary option schema for this rule. */
+interface SecondaryOptions {
+  allowInVariables?: boolean;
+  allowInFunctions?: boolean;
+  allowedColors?: string[];
+}
+
+/**
+ * Stylelint rule function for `sass/no-color-literals`.
+ *
+ * Walks all declarations and reports color literals (hex, named colors,
+ * rgb/hsl functions) used directly in property values. Colors should be
+ * stored in variables instead.
+ *
+ * Uses the sass-parser AST expression types (`_expression.sassType`) to
+ * accurately detect color literals, even when the parser normalizes values
+ * (e.g. named colors like `red` become `#ff0000`).
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @param secondaryOptions - Optional configuration object
+ * @returns A PostCSS plugin callback that walks declarations
+ *
+ * @example
+ * ```json
+ * { "sass/no-color-literals": [true, { "allowInVariables": true }] }
+ * ```
+ */
+const ruleFunction: stylelint.Rule<true, SecondaryOptions> = (primary, secondaryOptions) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(
+      result,
+      ruleName,
+      { actual: primary },
+      {
+        actual: secondaryOptions,
+        possible: {
+          allowInVariables: [true, false],
+          allowInFunctions: [true, false],
+          allowedColors: [(v: unknown) => typeof v === 'string'],
+        },
+        optional: true,
+      },
+    );
+    if (!validOptions) return;
+
+    const allowInVariables = secondaryOptions?.allowInVariables !== false;
+    const allowInFunctions = secondaryOptions?.allowInFunctions === true;
+    const allowedColors = new Set(
+      (secondaryOptions?.allowedColors ?? DEFAULT_ALLOWED_COLORS).map((c) => c.toLowerCase()),
+    );
+
+    root.walkDecls((decl) => {
+      const prop = decl.prop;
+
+      // Skip variable declarations when allowInVariables is true
+      if (allowInVariables && prop.startsWith('$')) return;
+
+      // Access the sass-parser expression tree for accurate type detection.
+      // The _expression property is set by sass-parser on Declaration nodes.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const expr = (decl as any)._expression;
+      if (!expr) return;
+
+      const colorLiterals = collectColorLiterals(expr, allowInFunctions, allowedColors);
+
+      for (const color of colorLiterals) {
+        utils.report({
+          message: messages.rejected(color),
+          node: decl,
+          result,
+          ruleName,
+        });
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Description
- Adds `sass/no-color-literals` rule that flags color literals (hex, named colors, color functions) in property values
- Supports options: `allowInVariables`, `allowInFunctions`, `allowedColors`
- Uses sass-parser AST expression types with original source text extraction to handle parser normalization
- Includes comprehensive tests (20 test cases) and documentation

## Test plan
- [x] `pnpm check` passes (285 tests)
- [x] BAD cases: hex colors, named colors, color functions in properties all flagged
- [x] GOOD cases: variables, map values, allowed colors, function contexts respected
- [x] Smoke test validates rule triggers on invalid.sass