### PR TITLE
Closes #26: add sass/selector-no-union-class-name rule

### DIFF
--- a/docs/rules/selector-no-union-class-name.md
+++ b/docs/rules/selector-no-union-class-name.md
@@ -1,0 +1,111 @@
+# sass/selector-no-union-class-name
+
+Disallow using the parent selector (`&`) to construct union class names like `&-suffix` or
+`&_suffix`. These create class names that cannot be searched in the codebase because the final name
+(e.g. `.block-element`) never appears literally in the source.
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+When `&` is concatenated with a string (e.g. `&-item` inside `.nav`), the compiled output is
+`.nav-item`. A developer searching the codebase for `.nav-item` will never find it because the
+class name is split across two lines. This makes refactoring, debugging, and onboarding harder.
+
+Legitimate uses of `&` that do **not** form union class names -- such as `&:hover` (pseudo-class),
+`&.is-active` (compound selector), `& .child` (descendant), or `& + .sibling` (combinator) -- are
+allowed because they do not obscure searchable class names.
+
+## Configuration
+
+```json
+{
+  "sass/selector-no-union-class-name": true
+}
+```
+
+## BAD
+
+```sass
+// Union with hyphen -- .nav-item can't be found via search
+.nav
+  &-item
+    display: inline-block
+```
+
+```sass
+// Union with underscore -- .card_header is unsearchable
+.card
+  &_header
+    font-weight: bold
+```
+
+```sass
+// CamelCase concatenation -- .btnPrimary is unsearchable
+.btn
+  &Primary
+    background: blue
+```
+
+```sass
+// BEM modifier -- .btn--disabled is unsearchable
+.btn
+  &--disabled
+    opacity: 0.5
+    pointer-events: none
+```
+
+```sass
+// Deep nesting compounds the problem
+// Produces .nav-list-item -- completely opaque
+.nav
+  &-list
+    margin: 0
+    &-item
+      display: inline
+```
+
+## GOOD
+
+```sass
+// Descendant selector -- & is followed by a space
+.nav
+  & .item
+    display: inline-block
+```
+
+```sass
+// Compound selector -- appends a class, not a string
+.btn
+  &.is-active
+    background: green
+```
+
+```sass
+// Pseudo-class -- not concatenation
+.link
+  &:hover
+    text-decoration: underline
+```
+
+```sass
+// Pseudo-element -- not concatenation
+.icon
+  &::before
+    content: ""
+    display: block
+```
+
+```sass
+// Standalone class -- the name is searchable as-is
+.nav-item
+  display: inline-block
+```
+
+```sass
+// Adjacent sibling combinator -- not concatenation
+.card
+  & + .card
+    margin-top: 16px
+```

--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -63,6 +63,11 @@
 @import "should-use-use-instead"
 @import "should-use-use-instead"
 
+// sass/selector-no-union-class-name
+.nav
+  &-item
+    display: inline-block
+
 // sass/dollar-variable-pattern
 $fontSize: 16px
 

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -59,6 +59,7 @@ describe('recommended config', () => {
         'sass/no-duplicate-load-rules',
         'sass/selector-no-redundant-nesting-selector',
         'sass/no-duplicate-dollar-variables',
+        'sass/selector-no-union-class-name',
       ]),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,6 +25,7 @@ import noDuplicateMixins from './rules/no-duplicate-mixins/index.js';
 import noDuplicateLoadRules from './rules/no-duplicate-load-rules/index.js';
 import selectorNoRedundantNestingSelector from './rules/selector-no-redundant-nesting-selector/index.js';
 import noDuplicateDollarVariables from './rules/no-duplicate-dollar-variables/index.js';
+import selectorNoUnionClassName from './rules/selector-no-union-class-name/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -46,6 +47,7 @@ const rules: stylelint.Plugin[] = [
   noDuplicateLoadRules,
   selectorNoRedundantNestingSelector,
   noDuplicateDollarVariables,
+  selectorNoUnionClassName,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -65,5 +65,6 @@ export default {
     'sass/no-duplicate-load-rules': true,
     'sass/selector-no-redundant-nesting-selector': true,
     'sass/no-duplicate-dollar-variables': true,
+    'sass/selector-no-union-class-name': true,
   },
 };

--- a/src/rules/selector-no-union-class-name/index.test.ts
+++ b/src/rules/selector-no-union-class-name/index.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/selector-no-union-class-name': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/selector-no-union-class-name', () => {
+  // BAD cases
+  it('rejects union with hyphen (&-item)', async () => {
+    const result = await lint('.nav\n  &-item\n    display: inline-block');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/selector-no-union-class-name');
+  });
+
+  it('rejects union with underscore (&_header)', async () => {
+    const result = await lint('.card\n  &_header\n    font-weight: bold');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/selector-no-union-class-name');
+  });
+
+  it('rejects camelCase concatenation (&Primary)', async () => {
+    const result = await lint('.btn\n  &Primary\n    background: blue');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/selector-no-union-class-name');
+  });
+
+  it('rejects BEM modifier (&--disabled)', async () => {
+    const result = await lint('.btn\n  &--disabled\n    opacity: 0.5\n    pointer-events: none');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/selector-no-union-class-name');
+  });
+
+  it('rejects deep nesting (&-list / &-item)', async () => {
+    const result = await lint('.nav\n  &-list\n    margin: 0\n    &-item\n      display: inline');
+    expect(result.warnings).toHaveLength(2);
+    expect(result.warnings[0].rule).toBe('sass/selector-no-union-class-name');
+    expect(result.warnings[1].rule).toBe('sass/selector-no-union-class-name');
+  });
+
+  // GOOD cases
+  it('accepts descendant selector (& .item)', async () => {
+    const result = await lint('.nav\n  & .item\n    display: inline-block');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts compound selector (&.is-active)', async () => {
+    const result = await lint('.btn\n  &.is-active\n    background: green');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts pseudo-class (&:hover)', async () => {
+    const result = await lint('.link\n  &:hover\n    text-decoration: underline');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts pseudo-element (&::before)', async () => {
+    const result = await lint('.icon\n  &::before\n    content: ""\n    display: block');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts standalone class (.nav-item)', async () => {
+    const result = await lint('.nav-item\n  display: inline-block');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts adjacent sibling combinator (& + .card)', async () => {
+    const result = await lint('.card\n  & + .card\n    margin-top: 16px');
+    expect(result.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/selector-no-union-class-name/index.ts
+++ b/src/rules/selector-no-union-class-name/index.ts
@@ -1,0 +1,98 @@
+/**
+ * Rule: `sass/selector-no-union-class-name`
+ *
+ * Disallow using the parent selector (`&`) to construct union class names
+ * like `&-suffix` or `&_suffix`. These create class names that cannot be
+ * searched in the codebase because the final name (e.g. `.block-element`)
+ * never appears literally in the source.
+ *
+ * @example
+ * ```sass
+ * // BAD — union with hyphen; .nav-item can't be found via search
+ * .nav
+ *   &-item
+ *     display: inline-block
+ *
+ * // GOOD — descendant selector; & is followed by a space
+ * .nav
+ *   & .item
+ *     display: inline-block
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/selector-no-union-class-name';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/selector-no-union-class-name.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: 'Unexpected union class name with parent selector (&)',
+});
+
+/**
+ * Pattern that matches `&` immediately followed by a character that forms
+ * a union class name: a letter, digit, hyphen, or underscore.
+ *
+ * This excludes valid uses like `&.class`, `&:pseudo`, `&::pseudo-element`,
+ * `& .descendant`, `& + .sibling`, `& ~ .general-sibling`, `& > .child`,
+ * and `&[attr]`.
+ */
+const unionPattern = /&[a-zA-Z0-9_-]/;
+
+/**
+ * Stylelint rule function for `sass/selector-no-union-class-name`.
+ *
+ * Walks all rules in the PostCSS AST and checks each selector for
+ * parent selector unions. Selector lists (comma-separated) are split
+ * and each part is checked independently.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback that walks rule selectors
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    root.walkRules((rule) => {
+      const selector = rule.selector;
+
+      // Split selector list by comma and check each part
+      const parts = selector.split(',');
+
+      for (const part of parts) {
+        const trimmed = part.trim();
+        if (unionPattern.test(trimmed)) {
+          utils.report({
+            message: messages.rejected,
+            node: rule,
+            result,
+            ruleName,
+            word: trimmed,
+          });
+        }
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Description
- Adds `sass/selector-no-union-class-name` rule that disallows constructing union class names via `&` (e.g., `&-item`, `&_header`, `&--disabled`)
- Detects hyphen, underscore, camelCase, and BEM modifier concatenation patterns
- Correctly allows compound selectors (`&.class`), pseudo-classes (`&:hover`), pseudo-elements (`&::before`), descendant (`& .item`), and combinators (`& + .cards`)

## Test plan
- [x] `pnpm check` passes
- [x] 5 BAD cases: hyphen, underscore, camelCase, BEM modifier, deep nesting
- [x] 6 GOOD cases: descendant, compound, pseudo-class, pseudo-element, standalone, combinator
- [x] Smoke test integration