### PR TITLE
Closes #27: add sass/dimension-no-non-numeric-values rule

### DIFF
--- a/docs/rules/dimension-no-non-numeric-values.md
+++ b/docs/rules/dimension-no-non-numeric-values.md
@@ -1,0 +1,121 @@
+# sass/dimension-no-non-numeric-values
+
+Disallow constructing dimension values by concatenating a number with a unit string.
+
+**Default**: `true`
+**Fixable**: No
+
+## Why?
+
+Sass supports two common (but dangerous) shortcuts for attaching a unit to a number:
+
+1. **String concatenation**: `$n + "px"` produces an unquoted string, not a true dimension. It
+   _looks_ like `10px` but Sass treats it as a string. Subsequent math (`$result / 2`) will fail at
+   compile time.
+2. **Interpolation + unit suffix**: `#{$n}px` also produces an unquoted string for the same reason.
+
+The safe alternative is **multiplication by a unit literal**: `$n * 1px`. This produces a genuine
+Sass number with a unit, fully compatible with arithmetic, comparisons, and `math.*` functions.
+
+## Configuration
+
+```json
+{
+  "sass/dimension-no-non-numeric-values": true
+}
+```
+
+## BAD
+
+```sass
+// String concatenation with a unit string
+.box
+  width: $n + "px"
+```
+
+```sass
+// Interpolation immediately followed by a unit
+.container
+  max-width: #{$column-count * 80}px
+```
+
+```sass
+// Concatenation with em
+.heading
+  font-size: $scale-factor + "em"
+```
+
+```sass
+// Concatenation with rem
+.body
+  margin-top: $spacing-value + "rem"
+```
+
+```sass
+// Interpolation with %
+.progress
+  width: #{$ratio * 100}%
+```
+
+```sass
+// Inside a mixin
+=responsive-width($count)
+  width: #{$count * 120}px
+```
+
+```sass
+// Inside a function return
+@function to-rem($px)
+  @return math.div($px, 16) + "rem"
+```
+
+## GOOD
+
+```sass
+// Multiply by a unit literal
+.box
+  width: $n * 1px
+```
+
+```sass
+// Division then multiply by unit
+.text
+  font-size: math.div($base-size, 16) * 1rem
+```
+
+```sass
+// Multiply with em
+.heading
+  font-size: $scale-factor * 1em
+```
+
+```sass
+// Multiply with %
+.progress
+  width: $ratio * 100%
+```
+
+```sass
+// Plain string concatenation (not a dimension)
+.greeting
+  content: "hello" + " world"
+```
+
+```sass
+// Direct dimension literals
+$padding: 16px
+$gutter: 1.5rem
+```
+
+```sass
+// Arithmetic between dimensioned values
+.wrapper
+  width: $total-width - $sidebar-width
+  padding: $base-padding + 4px
+```
+
+```sass
+// Interpolation in selectors is fine — only values are flagged
+.col-#{$i}
+  flex: 0 0 $i * 1%
+```

--- a/src/__tests__/fixtures/invalid.sass
+++ b/src/__tests__/fixtures/invalid.sass
@@ -86,3 +86,7 @@ $fontSize: 16px
 // sass/no-duplicate-dollar-variables
 $dupVar: red
 $dupVar: blue
+
+// sass/dimension-no-non-numeric-values
+.bad-dimension
+  width: $n + "px"

--- a/src/__tests__/smoke.test.ts
+++ b/src/__tests__/smoke.test.ts
@@ -60,6 +60,7 @@ describe('recommended config', () => {
         'sass/selector-no-redundant-nesting-selector',
         'sass/no-duplicate-dollar-variables',
         'sass/selector-no-union-class-name',
+        'sass/dimension-no-non-numeric-values',
       ]),
     );
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import noDuplicateLoadRules from './rules/no-duplicate-load-rules/index.js';
 import selectorNoRedundantNestingSelector from './rules/selector-no-redundant-nesting-selector/index.js';
 import noDuplicateDollarVariables from './rules/no-duplicate-dollar-variables/index.js';
 import selectorNoUnionClassName from './rules/selector-no-union-class-name/index.js';
+import dimensionNoNonNumericValues from './rules/dimension-no-non-numeric-values/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -48,6 +49,7 @@ const rules: stylelint.Plugin[] = [
   selectorNoRedundantNestingSelector,
   noDuplicateDollarVariables,
   selectorNoUnionClassName,
+  dimensionNoNonNumericValues,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -66,5 +66,6 @@ export default {
     'sass/selector-no-redundant-nesting-selector': true,
     'sass/no-duplicate-dollar-variables': true,
     'sass/selector-no-union-class-name': true,
+    'sass/dimension-no-non-numeric-values': true,
   },
 };

--- a/src/rules/dimension-no-non-numeric-values/index.test.ts
+++ b/src/rules/dimension-no-non-numeric-values/index.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/dimension-no-non-numeric-values': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+describe('sass/dimension-no-non-numeric-values', () => {
+  // BAD cases — should report
+
+  it('rejects string concat with px', async () => {
+    const result = await lint('.box\n  width: $n + "px"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/dimension-no-non-numeric-values');
+  });
+
+  it('rejects interpolation to build dimension with px', async () => {
+    const result = await lint('.container\n  max-width: #{$column-count * 80}px');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/dimension-no-non-numeric-values');
+  });
+
+  it('rejects concat with em', async () => {
+    const result = await lint('.heading\n  font-size: $scale-factor + "em"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/dimension-no-non-numeric-values');
+  });
+
+  it('rejects concat with rem', async () => {
+    const result = await lint('.body\n  margin-top: $spacing-value + "rem"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/dimension-no-non-numeric-values');
+  });
+
+  it('rejects interpolation with %', async () => {
+    const result = await lint('.progress\n  width: #{$ratio * 100}%');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/dimension-no-non-numeric-values');
+  });
+
+  it('rejects interpolation inside mixin body', async () => {
+    const result = await lint('=responsive-width($count)\n  width: #{$count * 120}px');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/dimension-no-non-numeric-values');
+  });
+
+  it('rejects concat in @return', async () => {
+    const result = await lint('@function to-rem($px)\n  @return math.div($px, 16) + "rem"');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/dimension-no-non-numeric-values');
+  });
+
+  // GOOD cases — should NOT report
+
+  it('accepts multiplication by unit literal (px)', async () => {
+    const result = await lint('.box\n  width: $n * 1px');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts division then multiply by unit (rem)', async () => {
+    const result = await lint('.text\n  font-size: math.div($base-size, 16) * 1rem');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts multiply with em', async () => {
+    const result = await lint('.heading\n  font-size: $scale-factor * 1em');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts multiply with %', async () => {
+    const result = await lint('.progress\n  width: $ratio * 100%');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts plain string concat (not a dimension)', async () => {
+    const result = await lint('.greeting\n  content: "hello" + " world"');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts direct dimension literals', async () => {
+    const result = await lint('$padding: 16px\n$gutter: 1.5rem');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts arithmetic between dimensioned values', async () => {
+    const result = await lint(
+      '.wrapper\n  width: $total-width - $sidebar-width\n  padding: $base-padding + 4px',
+    );
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts interpolation in selectors (not values)', async () => {
+    const result = await lint('.col-#{$i}\n  flex: 0 0 $i * 1%');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Edge cases
+
+  it('accepts single-quoted unit string concat as violation', async () => {
+    const result = await lint(".box\n  width: $n + 'px'");
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/dimension-no-non-numeric-values');
+  });
+
+  it('does not flag when rule is disabled', async () => {
+    const disabledConfig = {
+      plugins: ['./src/index.ts'],
+      customSyntax,
+      rules: { 'sass/dimension-no-non-numeric-values': [true] },
+    };
+    const result = await stylelint.lint({
+      code: '.box\n  width: $n * 1px',
+      config: disabledConfig,
+    });
+    expect(result.results[0]!.warnings).toHaveLength(0);
+  });
+});

--- a/src/rules/dimension-no-non-numeric-values/index.ts
+++ b/src/rules/dimension-no-non-numeric-values/index.ts
@@ -1,0 +1,165 @@
+/**
+ * Rule: `sass/dimension-no-non-numeric-values`
+ *
+ * Disallow constructing dimension values by concatenating a number with a
+ * unit string (e.g., `$n + "px"`). Use multiplication by a unit literal
+ * (`$n * 1px`) instead, which preserves type safety and avoids producing
+ * unquoted strings that only look like dimensions.
+ *
+ * @example
+ * ```sass
+ * // BAD — string concatenation to build a dimension
+ * .box
+ *   width: $n + "px"
+ *
+ * // BAD — interpolation followed by a unit
+ * .container
+ *   max-width: #{$column-count * 80}px
+ *
+ * // GOOD — multiply by a unit literal
+ * .box
+ *   width: $n * 1px
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/dimension-no-non-numeric-values';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/dimension-no-non-numeric-values.md',
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ *
+ * @example
+ * ```ts
+ * messages.rejectedConcat  // 'Unexpected dimension built via string concatenation. Use multiplication …'
+ * messages.rejectedInterp  // 'Unexpected dimension built via interpolation. Use multiplication …'
+ * ```
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejectedConcat:
+    'Unexpected dimension built via string concatenation. Use multiplication by a unit literal (e.g., $n * 1px) instead',
+  rejectedInterp:
+    'Unexpected dimension built via interpolation. Use multiplication by a unit literal (e.g., $n * 1px) instead',
+});
+
+/**
+ * All CSS unit keywords that this rule recognises when they appear after
+ * a `+` operator with a quoted string, or after an interpolation block.
+ */
+const UNITS = 'px|em|rem|%|vh|vw|vmin|vmax|ch|ex|cm|mm|in|pt|pc|deg|rad|grad|turn|s|ms';
+
+/**
+ * Matches string concatenation that builds a dimension value.
+ *
+ * Pattern: `+ "px"` or `+ 'rem'` etc.
+ */
+const STRING_CONCAT_RE = new RegExp(`\\+\\s*["'](?:${UNITS})["']`);
+
+/**
+ * Matches interpolation immediately followed by a CSS unit.
+ *
+ * Pattern: `#{...}px`, `#{...}%`, etc.
+ */
+const INTERPOLATION_UNIT_RE = new RegExp(`#\\{[^}]+\\}(?:${UNITS})(?![a-zA-Z])`);
+
+/**
+ * Extracts the original source text for a node from its source input.
+ *
+ * sass-parser may normalise certain expressions, so inspecting the raw
+ * source is necessary for reliable pattern detection.
+ *
+ * @param node - A PostCSS node with source position info
+ * @returns The original source text, or `undefined` if unavailable
+ */
+function getOriginalSource(node: {
+  source?: { input: { css: string }; start?: { offset: number }; end?: { offset: number } };
+}): string | undefined {
+  if (!node.source?.start || !node.source?.end) return undefined;
+  return node.source.input.css.slice(node.source.start.offset, node.source.end.offset + 1);
+}
+
+/**
+ * Stylelint rule function for `sass/dimension-no-non-numeric-values`.
+ *
+ * Walks declarations and `@return` at-rules, checking their value text
+ * against two patterns:
+ *
+ * 1. String concatenation: `+ "px"`, `+ "em"`, etc.
+ * 2. Interpolation + unit: `#{...}px`, `#{...}%`, etc.
+ *
+ * Only flags matches in declaration values and `@return` values, not in
+ * selectors or property names.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    // Check declaration values
+    root.walkDecls((decl) => {
+      const original = getOriginalSource(decl);
+      // Use original source if available, fall back to decl.value
+      const value = original ?? decl.value;
+
+      checkValue(value, decl);
+    });
+
+    // Check @return values
+    root.walkAtRules('return', (node) => {
+      const original = getOriginalSource(node);
+      // Use original source if available, fall back to node.params
+      const value = original ?? node.params;
+
+      checkValue(value, node);
+    });
+
+    /**
+     * Tests a value string against both detection patterns and reports
+     * a violation if either matches.
+     *
+     * @param value - The raw value text to check
+     * @param node - The PostCSS node to attach the warning to
+     */
+    function checkValue(value: string, node: Parameters<typeof utils.report>[0]['node']): void {
+      if (STRING_CONCAT_RE.test(value)) {
+        utils.report({
+          message: messages.rejectedConcat,
+          node,
+          result,
+          ruleName,
+        });
+      }
+
+      if (INTERPOLATION_UNIT_RE.test(value)) {
+        utils.report({
+          message: messages.rejectedInterp,
+          node,
+          result,
+          ruleName,
+        });
+      }
+    }
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Description

Adds `sass/dimension-no-non-numeric-values` rule that flags string concatenation for creating dimensions (e.g. `$n + "px"`, `#{$n}px`). This prevents creating unquoted strings that look like dimensions but break arithmetic operations.

The rule detects two dangerous patterns:
- String concatenation: `$n + "px"` produces a string, not a true dimension
- Interpolation + unit: `#{$n}px` also produces a string

Recommends using multiplication by unit literals (`$n * 1px`) which creates genuine Sass numbers compatible with math functions.

## Changes

- Adds rule implementation with regex patterns for both concatenation and interpolation detection
- Checks declaration values and `@return` statements for violations
- Includes comprehensive documentation with BAD/GOOD examples
- Adds 17 test cases covering various units (px, em, rem, %) and edge cases
- Integrates rule into recommended config and plugin exports
- Updates smoke test to validate rule triggers on test fixtures

## Test plan
- [x] All existing tests pass
- [x] BAD cases properly flagged: string concat with units, interpolation patterns
- [x] GOOD cases respected: proper arithmetic, unit literals, non-dimension strings
- [x] Edge cases handled: single quotes, selector interpolation ignored