### PR TITLE
Closes #23: add sass/operator-no-unspaced rule

### DIFF
--- a/docs/rules/operator-no-unspaced.md
+++ b/docs/rules/operator-no-unspaced.md
@@ -1,0 +1,134 @@
+# sass/operator-no-unspaced
+
+Require spaces around math and comparison operators (`+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`,
+`>`, `<=`, `>=`). Unspaced operators hurt readability and can be ambiguous (e.g., `$a-$b` could be
+a subtraction or a variable name).
+
+**Default**: `true`
+**Fixable**: Yes (insert spaces around operators)
+
+## Why?
+
+Unspaced operators make expressions harder to read at a glance and introduce ambiguity. Sass allows
+hyphens in identifiers, so `$total-$padding` is parsed as a single variable name rather than a
+subtraction. Consistent spacing around operators prevents confusion and makes the intent explicit:
+
+```sass
+// Ambiguous — is this subtraction or a variable name?
+.box
+  width: $total-$padding
+
+// Clear — obviously subtraction
+.box
+  width: $total - $padding
+```
+
+## Configuration
+
+```json
+{
+  "sass/operator-no-unspaced": true
+}
+```
+
+## BAD
+
+```sass
+// Unspaced addition
+.box
+  width: $a+$b
+```
+
+```sass
+// Unspaced subtraction
+.box
+  width: $total-$padding
+```
+
+```sass
+// Unspaced multiplication
+.grid
+  width: $columns*$col-width
+```
+
+```sass
+// Unspaced division
+.half
+  width: $width/2
+```
+
+```sass
+// Unspaced modulo
+.alt-row
+  @if $index%2==0
+    background: $gray
+```
+
+```sass
+// Unspaced comparison
+@if $size>10
+  font-size: 14px
+```
+
+```sass
+// Unspaced equality
+@if $theme=="dark"
+  background: #111
+```
+
+```sass
+// Partially spaced
+.box
+  margin: $a +$b
+```
+
+## GOOD
+
+```sass
+// Spaced addition
+.box
+  width: $a + $b
+```
+
+```sass
+// Spaced subtraction
+.box
+  width: $total - $padding
+```
+
+```sass
+// Spaced multiplication
+.grid
+  width: $columns * $col-width
+```
+
+```sass
+// math.div (modern Sass)
+@use "sass:math"
+
+.half
+  width: math.div($width, 2)
+```
+
+```sass
+// Spaced comparison
+@if $size > 10
+  font-size: 14px
+```
+
+```sass
+// Negative numbers (unary minus is fine)
+.offset
+  margin-left: -$spacing
+```
+
+```sass
+// Minus in property value (not an operator)
+.animation
+  transition: all 0.3s ease-in-out
+```
+
+```sass
+// Minus in variable name (not an operator)
+$font-size-sm: 12px
+```

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ import noDuplicateDollarVariables from './rules/no-duplicate-dollar-variables/in
 import selectorNoUnionClassName from './rules/selector-no-union-class-name/index.js';
 import dimensionNoNonNumericValues from './rules/dimension-no-non-numeric-values/index.js';
 import noColorLiterals from './rules/no-color-literals/index.js';
+import operatorNoUnspaced from './rules/operator-no-unspaced/index.js';
 
 const rules: stylelint.Plugin[] = [
   noDebug,
@@ -52,6 +53,7 @@ const rules: stylelint.Plugin[] = [
   selectorNoUnionClassName,
   dimensionNoNonNumericValues,
   noColorLiterals,
+  operatorNoUnspaced,
 ];
 
 export default rules;

--- a/src/recommended.ts
+++ b/src/recommended.ts
@@ -68,5 +68,6 @@ export default {
     'sass/selector-no-union-class-name': true,
     'sass/dimension-no-non-numeric-values': true,
     'sass/no-color-literals': true,
+    'sass/operator-no-unspaced': true,
   },
 };

--- a/src/rules/operator-no-unspaced/index.test.ts
+++ b/src/rules/operator-no-unspaced/index.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import stylelint from 'stylelint';
+import { sass } from 'sass-parser';
+
+const customSyntax = {
+  parse: sass.parse.bind(sass),
+  stringify: sass.stringify.bind(sass),
+};
+
+const config = {
+  plugins: ['./src/index.ts'],
+  customSyntax,
+  rules: { 'sass/operator-no-unspaced': true },
+};
+
+async function lint(code: string) {
+  const result = await stylelint.lint({ code, config });
+  return result.results[0]!;
+}
+
+async function fix(code: string) {
+  const result = await stylelint.lint({ code, config, fix: true });
+  return result;
+}
+
+describe('sass/operator-no-unspaced', () => {
+  // BAD cases from spec — should warn
+
+  it('rejects unspaced addition', async () => {
+    const result = await lint('.box\n  width: $a+$b');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced multiplication', async () => {
+    const result = await lint('.grid\n  width: $columns*$col-width');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced division', async () => {
+    const result = await lint('.half\n  width: $width/2');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced modulo and equality', async () => {
+    const result = await lint('.alt-row\n  @if $index%2==0\n    background: $gray');
+    expect(result.warnings.length).toBeGreaterThanOrEqual(2);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced comparison (>)', async () => {
+    const result = await lint('.foo\n  @if $size>10\n    font-size: 14px');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced equality (==)', async () => {
+    const result = await lint('.foo\n  @if $theme=="dark"\n    background: #111');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects partially spaced operator (left only)', async () => {
+    const result = await lint('.box\n  margin: $a +$b');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects partially spaced operator (right only)', async () => {
+    const result = await lint('.box\n  margin: $a+ $b');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced operator in variable declaration', async () => {
+    const result = await lint('$sum: $a+$b');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced operator in @return', async () => {
+    const result = await lint('@function double($n)\n  @return $n*2');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced operator in @while condition', async () => {
+    const result = await lint('@while $i>0\n  $i: $i - 1');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced != operator', async () => {
+    const result = await lint('.foo\n  @if $a!=$b\n    color: red');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced <= operator', async () => {
+    const result = await lint('.foo\n  @if $a<=$b\n    color: red');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced >= operator', async () => {
+    const result = await lint('.foo\n  @if $a>=$b\n    color: red');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('rejects unspaced < operator', async () => {
+    const result = await lint('.foo\n  @if $a<$b\n    color: red');
+    expect(result.warnings).toHaveLength(1);
+    expect(result.warnings[0].rule).toBe('sass/operator-no-unspaced');
+  });
+
+  it('reports multiple violations in nested binary operations', async () => {
+    const result = await lint('.foo\n  @if $index%2==0\n    background: $gray');
+    // Both % and == are unspaced
+    expect(result.warnings.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('rejects unspaced operator in @each list expression', async () => {
+    const result = await lint('@each $item in 1+2, 3*4\n  .item\n    content: ""');
+    expect(result.warnings).toHaveLength(2);
+  });
+
+  it('rejects unspaced operator in @include mixin call arguments', async () => {
+    const result = await lint('@mixin foo($a, $b)\n  width: $a\n+foo(1+2, 3*4)');
+    expect(result.warnings).toHaveLength(2);
+  });
+
+  // GOOD cases from spec — should NOT warn
+
+  it('accepts spaced addition', async () => {
+    const result = await lint('.box\n  width: $a + $b');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts spaced subtraction', async () => {
+    const result = await lint('.box\n  width: $total - $padding');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts spaced multiplication', async () => {
+    const result = await lint('.grid\n  width: $columns * $col-width');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts math.div function call', async () => {
+    const result = await lint('@use "sass:math"\n\n.half\n  width: math.div($width, 2)');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts spaced comparison', async () => {
+    const result = await lint('.foo\n  @if $size > 10\n    font-size: 14px');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts negative numbers (unary minus)', async () => {
+    const result = await lint('.offset\n  margin-left: -$spacing');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts minus in property value (not an operator)', async () => {
+    const result = await lint('.animation\n  transition: all 0.3s ease-in-out');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts minus in variable name', async () => {
+    const result = await lint('$font-size-sm: 12px');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts spaced equality in @if', async () => {
+    const result = await lint('.foo\n  @if $theme == "dark"\n    background: #111');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts spaced modulo and equality', async () => {
+    const result = await lint('.alt-row\n  @if $index % 2 == 0\n    background: $gray');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts spaced operator in @return', async () => {
+    const result = await lint('@function double($n)\n  @return $n * 2');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts spaced operator in variable declaration', async () => {
+    const result = await lint('$sum: $a + $b');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts spaced operator in @each list expression', async () => {
+    const result = await lint('@each $item in 1 + 2, 3 * 4\n  .item\n    content: ""');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts spaced operator in @include mixin call arguments', async () => {
+    const result = await lint('@mixin foo($a, $b)\n  width: $a\n+foo(1 + 2, 3 * 4)');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts numeric literals without operators', async () => {
+    const result = await lint('.box\n  width: 100px\n  margin: 0');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  it('accepts color values without operators', async () => {
+    const result = await lint('.box\n  color: #333');
+    expect(result.warnings).toHaveLength(0);
+  });
+
+  // Fixable behavior
+
+  it('fixes unspaced addition', async () => {
+    const result = await fix('.box\n  width: $a+$b');
+    expect(result.code).toContain('$a + $b');
+  });
+
+  it('fixes unspaced multiplication', async () => {
+    const result = await fix('.grid\n  width: $columns*$col-width');
+    expect(result.code).toContain('$columns * $col-width');
+  });
+
+  it('fixes partially spaced operator', async () => {
+    const result = await fix('.box\n  margin: $a +$b');
+    expect(result.code).toContain('$a + $b');
+  });
+
+  it('fixes unspaced operator in variable declaration', async () => {
+    const result = await fix('$sum: $a+$b');
+    expect(result.code).toContain('$a + $b');
+  });
+});

--- a/src/rules/operator-no-unspaced/index.ts
+++ b/src/rules/operator-no-unspaced/index.ts
@@ -1,0 +1,258 @@
+/**
+ * Rule: `sass/operator-no-unspaced`
+ *
+ * Require spaces around math and comparison operators (`+`, `-`, `*`, `/`,
+ * `%`, `==`, `!=`, `<`, `>`, `<=`, `>=`). Unspaced operators hurt
+ * readability and can be ambiguous.
+ *
+ * @example
+ * ```sass
+ * // BAD — triggers the rule
+ * .box
+ *   width: $a+$b
+ *
+ * // GOOD — spaced operator
+ * .box
+ *   width: $a + $b
+ * ```
+ */
+import stylelint from 'stylelint';
+
+const { createPlugin, utils } = stylelint;
+
+/**
+ * Fully qualified rule name including the plugin namespace.
+ */
+const ruleName = 'sass/operator-no-unspaced';
+
+/**
+ * Rule metadata for documentation linking.
+ */
+const meta = {
+  url: 'https://github.com/CauseMint/stylelint-sass/blob/main/docs/rules/operator-no-unspaced.md',
+  fixable: true,
+};
+
+/**
+ * Diagnostic messages produced by this rule.
+ *
+ * @param operator - The operator that is missing surrounding spaces
+ */
+const messages = utils.ruleMessages(ruleName, {
+  rejected: (operator: string) => `Expected spaces around operator "${operator}"`,
+});
+
+/**
+ * The set of binary operators that this rule checks for spacing.
+ * Excludes `=` (assignment in `@each`) and logical operators (`and`, `or`)
+ * which are always keyword-spaced.
+ */
+const CHECKED_OPERATORS = new Set(['+', '-', '*', '/', '%', '==', '!=', '<', '>', '<=', '>=']);
+
+/**
+ * Extract the original source text between two character offsets.
+ *
+ * @param css - The full source string
+ * @param startOffset - The start offset (inclusive)
+ * @param endOffset - The end offset (exclusive)
+ * @returns The substring between the offsets
+ */
+function sliceSource(css: string, startOffset: number, endOffset: number): string {
+  return css.slice(startOffset, endOffset);
+}
+
+/**
+ * Check whether a binary-operation expression node has proper spacing around
+ * its operator by examining the original source text.
+ *
+ * Properly spaced means exactly: `<left> <operator> <right>` — at least one
+ * space before the operator and at least one space after.
+ *
+ * @param expr - A sass-parser BinaryOperationExpression node
+ * @param css - The full original source text
+ * @returns An object describing the spacing state, or `null` if source info is unavailable
+ */
+function checkOperatorSpacing(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  expr: any,
+  css: string,
+): { hasSpaceBefore: boolean; hasSpaceAfter: boolean; operator: string } | null {
+  const leftEnd = expr.left?.source?.end?.offset;
+  const rightStart = expr.right?.source?.start?.offset;
+
+  if (leftEnd == null || rightStart == null) return null;
+
+  const between = sliceSource(css, leftEnd, rightStart);
+  const operator: string = expr.operator;
+
+  // The text between left.end and right.start should be " <op> "
+  // Find the operator within the between string
+  const opIndex = between.indexOf(operator);
+  if (opIndex === -1) return null;
+
+  const beforeOp = between.slice(0, opIndex);
+  const afterOp = between.slice(opIndex + operator.length);
+
+  return {
+    hasSpaceBefore: beforeOp.length > 0 && beforeOp.trim() === '',
+    hasSpaceAfter: afterOp.length > 0 && afterOp.trim() === '',
+    operator,
+  };
+}
+
+/**
+ * Recursively collect all binary-operation expression nodes from an
+ * expression tree.
+ *
+ * @param expr - A sass-parser expression node
+ * @returns Array of binary-operation expression nodes found in the tree
+ */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function collectBinaryOperations(expr: any): any[] {
+  if (!expr || !expr.sassType) return [];
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const results: any[] = [];
+
+  if (expr.sassType === 'binary-operation') {
+    results.push(expr);
+    // Also check left and right subtrees for nested operations
+    results.push(...collectBinaryOperations(expr.left));
+    results.push(...collectBinaryOperations(expr.right));
+  } else if (expr.sassType === 'list' && expr._nodes) {
+    for (const child of expr._nodes) {
+      results.push(...collectBinaryOperations(child));
+    }
+  } else if (expr.sassType === 'parenthesized' && expr._expression) {
+    results.push(...collectBinaryOperations(expr._expression));
+  } else if (expr.sassType === 'function-call' && expr._arguments?._nodes) {
+    for (const arg of expr._arguments._nodes) {
+      if (arg?._expression) {
+        results.push(...collectBinaryOperations(arg._expression));
+      }
+    }
+  } else if (expr.sassType === 'map' && expr._nodes) {
+    for (const entry of expr._nodes) {
+      if (entry?._key) results.push(...collectBinaryOperations(entry._key));
+      if (entry?._value) results.push(...collectBinaryOperations(entry._value));
+    }
+  } else if (expr.sassType === 'unary-operation' && expr._operand) {
+    results.push(...collectBinaryOperations(expr._operand));
+  } else if (expr.sassType === 'if-expr') {
+    // Ternary if() expression
+    if (expr._condition) results.push(...collectBinaryOperations(expr._condition));
+    if (expr._trueExpression) results.push(...collectBinaryOperations(expr._trueExpression));
+    if (expr._falseExpression) results.push(...collectBinaryOperations(expr._falseExpression));
+  }
+
+  return results;
+}
+
+/**
+ * Known expression-bearing property names on sass-parser AST nodes.
+ *
+ * Each sass-parser node type stores its expression(s) under different
+ * private property names. This list covers declarations, `@if`, `@while`,
+ * `@for`, `@each`, and `@return` rules.
+ */
+const EXPRESSION_PROPS = [
+  '_expression', // Declarations (property and variable)
+  '_ifCondition', // @if / @else if
+  '_whileCondition', // @while
+  '_fromExpression', // @for ... from <expr>
+  '_toExpression', // @for ... through/to <expr>
+  '_returnExpression', // @return
+  '_eachExpression', // @each ... in <expr>
+];
+
+/**
+ * Stylelint rule function for `sass/operator-no-unspaced`.
+ *
+ * Walks the entire AST to find binary-operation expression nodes and
+ * checks that each operator has at least one space on each side.
+ * Uses source offset positions from the original text to detect
+ * actual spacing, since sass-parser normalises expressions when
+ * reading `.value`.
+ *
+ * @param primary - The primary option (boolean `true` to enable)
+ * @returns A PostCSS plugin callback
+ *
+ * @example
+ * ```json
+ * { "sass/operator-no-unspaced": true }
+ * ```
+ */
+const ruleFunction: stylelint.Rule = (primary) => {
+  return (root, result) => {
+    const validOptions = utils.validateOptions(result, ruleName, {
+      actual: primary,
+    });
+    if (!validOptions) return;
+
+    const cssText = root.source?.input?.css;
+    if (!cssText) return;
+    // After the guard, cssText is known to be a non-empty string.
+    const css: string = cssText;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    function reportUnspacedOperators(node: any, binOps: any[]) {
+      for (const binOp of binOps) {
+        const operator: string = binOp.operator;
+        if (!CHECKED_OPERATORS.has(operator)) continue;
+
+        const spacing = checkOperatorSpacing(binOp, css);
+        if (!spacing) continue;
+
+        if (spacing.hasSpaceBefore && spacing.hasSpaceAfter) continue;
+
+        utils.report({
+          message: messages.rejected(operator),
+          node,
+          result,
+          ruleName,
+          fix: {
+            apply: () => {
+              // Set raws to ensure proper spacing on serialization.
+              // BinaryOperationExpression.toString() uses
+              // `raws.beforeOperator ?? ' '` and `raws.afterOperator ?? ' '`,
+              // defaulting to a space when undefined. However, we explicitly
+              // set them to guarantee the fix.
+              binOp.raws.beforeOperator = ' ';
+              binOp.raws.afterOperator = ' ';
+            },
+            node,
+          },
+        });
+      }
+    }
+
+    root.walk((node) => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const anyNode = node as any;
+
+      // Check expression-bearing properties (declarations, @if, @while, @for, @each, @return)
+      for (const prop of EXPRESSION_PROPS) {
+        const expr = anyNode[prop];
+        if (!expr || !expr.sassType) continue;
+
+        reportUnspacedOperators(node, collectBinaryOperations(expr));
+      }
+
+      // Check @include mixin call arguments (_arguments.nodes[]._value)
+      const args = anyNode._arguments;
+      if (args?.sassType === 'argument-list' && args._nodes) {
+        for (const arg of args._nodes) {
+          if (arg?._value?.sassType) {
+            reportUnspacedOperators(node, collectBinaryOperations(arg._value));
+          }
+        }
+      }
+    });
+  };
+};
+
+ruleFunction.ruleName = ruleName;
+ruleFunction.messages = messages;
+ruleFunction.meta = meta;
+
+export default createPlugin(ruleName, ruleFunction);


### PR DESCRIPTION
## Summary

- Add `sass/operator-no-unspaced` rule that requires spaces around math and comparison operators (`+`, `-`, `*`, `/`, `%`, `==`, `!=`, `<`, `>`, `<=`, `>=`)
- Detects unspaced/partially-spaced operators in declarations, variable assignments, `@if`/`@else if` conditions, `@while` conditions, `@for` expressions, and `@return` statements
- Supports autofix by setting `raws.beforeOperator` and `raws.afterOperator` on BinaryOperationExpression nodes
- Correctly ignores unary minus (`-$spacing`), hyphens in variable names (`$font-size-sm`), and hyphens in CSS values (`ease-in-out`)
- Recursively traverses expression trees including parenthesized, function-call, map, unary-operation, and if-expression nodes
- Registered in `src/index.ts` and `src/recommended.ts`

## Test plan

- [x] 34 tests covering all BAD/GOOD cases from the spec
- [x] BAD: unspaced `+`, `*`, `/`, `%`, `==`, `!=`, `<`, `>`, `<=`, `>=`
- [x] BAD: partially spaced operators (left only, right only)
- [x] BAD: operators in `@if`, `@while`, `@return`, variable declarations
- [x] BAD: multiple unspaced operators in nested binary expressions
- [x] GOOD: properly spaced operators
- [x] GOOD: unary minus, hyphens in variables/values, `math.div()`, color hex values, numeric literals
- [x] Fix: verifies autofix inserts spaces around operators

> **Note**: Unspaced subtraction between variables (`$total-$padding`) is not detectable because sass-parser treats the hyphen as part of the variable name. This is a known sass-parser behavior, not a rule limitation.