### PR TITLE
Closes #67: mount host auth and context into devcontainer

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,7 +1,8 @@
 # Dev Container
 
 A sandboxed development environment for stylelint-sass. Pre-installs Node 22, pnpm, gh CLI,
-Graphite CLI, and Claude Code so contributors can start working immediately.
+Graphite CLI, and Claude Code so contributors can start working immediately. Host authentication
+and context persist across container rebuilds via bind mounts.
 
 ## Why a Dev Container?
 
@@ -11,6 +12,11 @@ risking your host machine. Outside a sandbox, every tool call requires manual ap
 defeats the purpose of agentic workflows.
 
 ## Opening the project
+
+Open the **main repo folder** in your editor. The CLAUDE.md workflow orchestrates worktree creation
+inside the container via skills (`/worktree`, `/add-rule`, `/review-pr`), so the main tree stays on
+`main` and branches live in `.worktrees/`. Worktrees persist across rebuilds because they live on
+the bind-mounted host filesystem.
 
 ### VS Code
 
@@ -49,6 +55,100 @@ claude!
 This is equivalent to `claude --dangerously-skip-permissions`. It is safe to use because the
 container is isolated from your host machine.
 
+## Host state persistence
+
+Host directories are bind-mounted into the container. CLI auth (`gh`, `gt`) and session data
+(`~/.claude/projects`) are mounted directly. Claude config (`~/.claude`, `~/.claude.json`) uses
+**staging paths** so the installer writes to a container-local copy first, then
+`link-claude-config.sh` symlinks specific files back to the host mount.
+
+<!-- markdownlint-disable MD013 -->
+
+| Host path             | Container path                 | What persists                                               |
+| --------------------- | ------------------------------ | ----------------------------------------------------------- |
+| `~/.claude/`          | `/home/node/.claude-host/`     | Source for credentials, MCP config, settings (via symlinks) |
+| `~/.claude/projects/` | `/home/node/.claude/projects/` | Sessions and auto-memory (direct mount)                     |
+| `~/.claude.json`      | `/home/node/.claude-host.json` | OAuth session, project settings                             |
+| `~/.config/gh/`       | `/home/node/.config/gh/`       | GitHub CLI auth (`gh auth login`)                           |
+| `~/.config/graphite/` | `/home/node/.config/graphite/` | Graphite CLI auth                                           |
+
+<!-- markdownlint-enable MD013 -->
+
+After `claude install`, `link-claude-config.sh` symlinks these container-local files to the staging
+mount:
+
+- `~/.claude.json` -> `~/.claude-host.json`
+- `~/.claude/.credentials.json` -> `~/.claude-host/.credentials.json`
+- `~/.claude/.mcp.json` -> `~/.claude-host/.mcp.json` (also registered into `~/.claude.json`)
+- `~/.claude/settings.local.json` -> `~/.claude-host/settings.local.json`
+- `~/.claude/projects/` — session files hard-linked between host and container encoded dirs
+- `~/.claude/history.jsonl` — host entries merged with rewritten project paths
+
+Git config (`~/.gitconfig`) and SSH agent are forwarded automatically by VS Code — no mount needed.
+
+### Cross-environment `/resume`
+
+Claude Code stores sessions as `.jsonl` files in `~/.claude/projects/<encoded-path>/` and discovers
+resumable sessions by scanning directories that match the encoded project path. Since the repo lives
+at different absolute paths on host vs container (e.g., `~/workspace/sass-lint` vs
+`/workspaces/sass-lint`), session files created on one side aren't found by the other.
+
+`link-claude-config.sh` fixes this by hard-linking session files between host-encoded and
+container-encoded project directories. Both directories live on the same bind mount
+(`~/.claude/projects`), so hard links share inodes — reads and writes through either path update the
+same underlying file.
+
+This means:
+
+- **Host -> container**: start a session on the host, `/resume` it inside the container
+- **Container -> host**: start a session in the container, `/resume` it on the host
+
+### Using worktrees on the host (optional)
+
+Worktrees created inside the container have container-absolute paths in their `.git` files (e.g.,
+`gitdir: /workspaces/sass-lint/.git/worktrees/feature`). These don't resolve on the host because
+`/workspaces/sass-lint/` only exists inside the container.
+
+To make them work on the host, run once:
+
+```bash
+.devcontainer/fix-host-worktrees.sh
+```
+
+This creates a symlink on the host (`/workspaces/<repo> → <actual-repo-path>`) so container paths
+resolve transparently. Requires `sudo` for creating `/workspaces/`. The devcontainer is not affected
+— it continues to use its native paths.
+
+**First-time setup**: authenticate each tool once on your host. After that, every container rebuild
+picks up existing auth automatically.
+
+```bash
+# On your host (one-time)
+gh auth login
+gt auth              # if using Graphite
+claude               # completes OAuth login
+```
+
+## PAL MCP Server (recommended)
+
+[PAL MCP Server](https://github.com/BeehiveInnovations/pal-mcp-server) enables local AI code
+review via the `/review-pr` skill (Phase 1: `mcp__pal__codereview`). Local review catches issues
+before CI, saving a full push-and-wait round-trip.
+
+**How it works**: `link-claude-config.sh` symlinks `~/.claude/.mcp.json` to the host staging mount
+AND registers the server definitions into `~/.claude.json` (the same place `claude mcp add` writes).
+This is necessary because Claude Code requires servers to be registered at the top-level `mcpServers`
+key in `~/.claude.json` — merely having a `.mcp.json` file is not enough. If you have PAL configured
+on your host, it's available inside the container with no extra setup.
+
+**First-time setup** (on your host, not inside the container):
+
+1. Install PAL following the
+   [instructions](https://github.com/BeehiveInnovations/pal-mcp-server#installation)
+2. Ensure API keys (e.g. `GEMINI_API_KEY`) are available — for Codespaces, add them as
+   [encrypted secrets](https://docs.github.com/en/codespaces/managing-your-codespaces/managing-encrypted-secrets-for-your-codespaces)
+3. Verify PAL works: inside the container, run `/mcp` in Claude Code — PAL tools should appear
+
 ## What's included
 
 | Tool            | Purpose                                  |
@@ -57,6 +157,7 @@ container is isolated from your host machine.
 | gh CLI          | GitHub issue/PR management               |
 | Graphite CLI    | Stacked PRs and branch workflow          |
 | Claude Code     | AI-powered development assistant         |
+| uv + uvx        | Python package runner (required by PAL)  |
 | ESLint          | Linting (via VS Code extension)          |
 | Prettier        | Formatting (via VS Code extension)       |
 | markdownlint    | Markdown linting (via VS Code extension) |

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,20 @@
   "features": {
     "ghcr.io/devcontainers/features/github-cli:1": {}
   },
-  "postCreateCommand": "pnpm install && npm i -g @withgraphite/graphite-cli && curl -fsSL https://claude.ai/install.sh | bash && echo \"alias claude!='claude --dangerously-skip-permissions'\" >> ~/.bashrc",
+  "initializeCommand": "mkdir -p ${HOME}/.claude/projects ${HOME}/.config/gh ${HOME}/.config/graphite && [ -f ${HOME}/.claude.json ] || touch ${HOME}/.claude.json",
+  "mounts": [
+    "source=${localEnv:HOME}/.claude,target=/home/node/.claude-host,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.claude/projects,target=/home/node/.claude/projects,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.claude.json,target=/home/node/.claude-host.json,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/gh,target=/home/node/.config/gh,type=bind,consistency=cached",
+    "source=${localEnv:HOME}/.config/graphite,target=/home/node/.config/graphite,type=bind,consistency=cached"
+  ],
+  "remoteEnv": {
+    "HOST_PROJECT_PATH": "${localWorkspaceFolder}",
+    "CONTAINER_WORKSPACE_FOLDER": "${containerWorkspaceFolder}"
+  },
+  "postCreateCommand": ".devcontainer/install-tools.sh",
+  "postStartCommand": ".devcontainer/link-claude-config.sh",
   "customizations": {
     "vscode": {
       "extensions": [

--- a/.devcontainer/fix-host-worktrees.sh
+++ b/.devcontainer/fix-host-worktrees.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# fix-host-worktrees.sh
+#
+# Optional host-side script that makes worktrees created inside the devcontainer
+# usable from the host. Run once on your host machine.
+#
+# Problem: Worktrees created inside the container have container-absolute paths
+# in their .git files (e.g., gitdir: /workspaces/sass-lint/.git/worktrees/feature).
+# On the host, /workspaces/sass-lint/ doesn't exist, so git operations fail.
+#
+# Solution: Create a symlink on the host so container paths resolve:
+#   /workspaces/sass-lint → ~/workspace/sass-lint
+#
+# This does NOT modify anything inside the devcontainer. The container continues
+# to use its native paths. The host follows the symlink transparently.
+#
+# Usage (from repo root on host):
+#   .devcontainer/fix-host-worktrees.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+REPO_NAME="$(basename "$REPO_DIR")"
+CONTAINER_PATH="/workspaces/$REPO_NAME"
+
+if [ -L "$CONTAINER_PATH" ]; then
+  EXISTING="$(readlink "$CONTAINER_PATH")"
+  if [ "$EXISTING" = "$REPO_DIR" ]; then
+    echo "fix-host-worktrees: $CONTAINER_PATH → $REPO_DIR (already set)"
+    exit 0
+  fi
+  echo "fix-host-worktrees: $CONTAINER_PATH exists but points to $EXISTING (expected $REPO_DIR)" >&2
+  exit 1
+fi
+
+if [ -e "$CONTAINER_PATH" ]; then
+  echo "fix-host-worktrees: $CONTAINER_PATH already exists (not a symlink), skipping" >&2
+  exit 1
+fi
+
+sudo mkdir -p /workspaces
+sudo ln -sfn "$REPO_DIR" "$CONTAINER_PATH"
+echo "fix-host-worktrees: $CONTAINER_PATH → $REPO_DIR"
+echo "Worktrees created inside the devcontainer will now work on the host."

--- a/.devcontainer/install-tools.sh
+++ b/.devcontainer/install-tools.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# install-tools.sh
+#
+# Runs once via postCreateCommand when the container is first created (or rebuilt).
+# Installs project dependencies and global CLI tools.
+#
+# Host Claude config is mounted at /home/node/.claude-host (staging path),
+# NOT at ~/.claude. The installer writes to container-local ~/.claude safely.
+# Auth/config symlinking happens later in link-claude-config.sh (postStartCommand).
+
+set -euo pipefail
+
+# --- Project dependencies ---
+CI=1 pnpm install
+
+# --- Global CLIs ---
+npm i -g @withgraphite/graphite-cli
+
+# --- Claude Code (writes to container-local ~/.claude — no host interference) ---
+# The ~/.claude/projects bind mount causes Docker to create ~/.claude as root.
+# Fix ownership so the installer (and Claude Code itself) can write to it.
+sudo chown "$(id -u):$(id -g)" "$HOME/.claude"
+curl -fsSL https://claude.ai/install.sh | bash
+
+# --- uv/uvx (for PAL MCP server) ---
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# --- Shell config ---
+grep -q 'alias claude!' ~/.bashrc 2>/dev/null || \
+  echo "alias claude!='claude --dangerously-skip-permissions'" >> ~/.bashrc
+grep -q '.local/bin' ~/.bashrc 2>/dev/null || \
+  echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc

--- a/.devcontainer/link-claude-config.sh
+++ b/.devcontainer/link-claude-config.sh
@@ -1,0 +1,245 @@
+#!/usr/bin/env bash
+# link-claude-config.sh
+#
+# Symlinks Claude Code auth, config, and session files from the container-local
+# ~/.claude to the host staging mount at ~/.claude-host. This provides:
+#
+#   - Auth persistence across rebuilds (credentials survive installer overwrites)
+#   - Bidirectional session sync (host <-> container /resume works)
+#   - Host MCP config available in container
+#   - Installer isolation (claude install writes to container-local dir only)
+#
+# Runs via postStartCommand on every container start (including the first start
+# after postCreateCommand installs Claude Code).
+
+set -euo pipefail
+
+STAGING="/home/node/.claude-host"
+STAGING_JSON="/home/node/.claude-host.json"
+CLAUDE_DIR="${HOME}/.claude"
+CLAUDE_JSON="${HOME}/.claude.json"
+
+# --- Helper: create a symlink from $target -> $source ---
+# If the container has a real file but host staging doesn't, seeds the host first.
+# Always creates the symlink (even dangling) so future writes go to the host.
+link_file() {
+  local target="$1"   # container-local path (will become symlink)
+  local source="$2"   # staging mount path (host file)
+
+  # Already correctly linked — nothing to do
+  if [[ -L "$target" ]] && [[ "$(readlink "$target")" == "$source" ]]; then
+    return 0
+  fi
+
+  mkdir -p "$(dirname "$target")"
+  mkdir -p "$(dirname "$source")"
+
+  # If container has a real file but host doesn't, seed host from container
+  # (first-build case: user authenticated in container, tokens need to reach host)
+  if [[ -e "$target" ]] && [[ ! -L "$target" ]] && [[ ! -e "$source" ]]; then
+    cp -a "$target" "$source"
+  fi
+
+  # Remove existing file/dir/symlink at target
+  rm -rf "$target"
+
+  # Create symlink (may be dangling if source doesn't exist yet — that's OK;
+  # when Claude writes the file, it goes through to the staging mount)
+  ln -s "$source" "$target"
+}
+
+# --- 1. Top-level config (OAuth session, project settings) ---
+link_file "$CLAUDE_JSON" "$STAGING_JSON"
+echo "link-claude-config: ~/.claude.json -> staging"
+
+# --- 2. Auth credentials ---
+link_file "$CLAUDE_DIR/.credentials.json" "$STAGING/.credentials.json"
+echo "link-claude-config: .credentials.json -> staging"
+
+# --- 3. MCP server config ---
+link_file "$CLAUDE_DIR/.mcp.json" "$STAGING/.mcp.json"
+echo "link-claude-config: .mcp.json -> staging"
+
+# --- 3b. Register MCP servers from .mcp.json into ~/.claude.json ---
+# Claude Code CLI stores user-scope MCP servers at the top-level "mcpServers"
+# key in ~/.claude.json — NOT in the .mcp.json file. The .mcp.json file is
+# treated as an external config needing per-project approval. To make servers
+# available automatically, we copy definitions from .mcp.json into the
+# ~/.claude.json top-level mcpServers (the same place `claude mcp add` writes).
+MCP_JSON="$CLAUDE_DIR/.mcp.json"
+CONTAINER_PATH_FOR_MCP="${CONTAINER_WORKSPACE_FOLDER:-$PWD}"
+if [[ -f "$MCP_JSON" ]] && [[ -f "$CLAUDE_JSON" ]]; then
+  python3 -c "
+import json, sys
+
+mcp_path = '$MCP_JSON'
+claude_json_path = '$CLAUDE_JSON'
+container_path = '$CONTAINER_PATH_FOR_MCP'
+
+try:
+    with open(mcp_path) as f:
+        mcp = json.load(f)
+    servers = mcp.get('mcpServers', {})
+    if not servers:
+        sys.exit(0)
+
+    with open(claude_json_path) as f:
+        cj = json.load(f)
+
+    # Merge .mcp.json servers into top-level mcpServers (user scope).
+    # Existing entries are preserved; new ones are added.
+    top_servers = cj.setdefault('mcpServers', {})
+    added = []
+    for name, config in servers.items():
+        if name not in top_servers:
+            # Add 'type' field expected by Claude Code CLI
+            entry = dict(config)
+            entry.setdefault('type', 'stdio')
+            top_servers[name] = entry
+            added.append(name)
+
+    # Also ensure project trust flags are set so Claude doesn't block
+    # on first-run dialogs for this project path.
+    projects = cj.setdefault('projects', {})
+    proj = projects.setdefault(container_path, {})
+    proj['hasTrustDialogAccepted'] = True
+    proj['hasCompletedProjectOnboarding'] = True
+
+    if added:
+        with open(claude_json_path, 'w') as f:
+            json.dump(cj, f, indent=2)
+            f.write('\n')
+        print(f'link-claude-config: registered MCP servers: {added}')
+    else:
+        # Still write trust flags if they changed
+        with open(claude_json_path, 'w') as f:
+            json.dump(cj, f, indent=2)
+            f.write('\n')
+        print(f'link-claude-config: MCP servers already registered: {list(servers.keys())}')
+except Exception as e:
+    print(f'link-claude-config: MCP registration failed: {e}', file=sys.stderr)
+" 2>&1 || echo "link-claude-config: MCP registration skipped (python3 unavailable)"
+fi
+
+# --- 4. User permission settings ---
+link_file "$CLAUDE_DIR/settings.local.json" "$STAGING/settings.local.json"
+echo "link-claude-config: settings.local.json -> staging"
+
+# --- 5. Session project directories ---
+# Claude Code discovers sessions by scanning ~/.claude/projects/ directories
+# whose names match encoded project paths. Since the repo lives at different
+# absolute paths on host vs container (e.g., ~/workspace/sass-lint vs
+# /workspaces/sass-lint), session files are hard-linked between both
+# encoded directories. Both dirs live on the same bind mount, so hard links
+# share inodes — reads/writes through either path update the same file.
+
+HOST_PATH="${HOST_PROJECT_PATH:-}"
+CONTAINER_PATH="${CONTAINER_WORKSPACE_FOLDER:-$PWD}"
+PROJECTS_DIR="${CLAUDE_DIR}/projects"
+
+if [[ -n "$HOST_PATH" ]]; then
+  # Claude Code encodes project paths by replacing / and . with -
+  encode_path() {
+    echo "$1" | tr '/.' '--'
+  }
+
+  HOST_ENCODED="$(encode_path "$HOST_PATH")"
+  CONTAINER_ENCODED="$(encode_path "$CONTAINER_PATH")"
+
+  HOST_SESSION_DIR="${PROJECTS_DIR}/${HOST_ENCODED}"
+  CONTAINER_SESSION_DIR="${PROJECTS_DIR}/${CONTAINER_ENCODED}"
+
+  mkdir -p "$HOST_SESSION_DIR"
+  mkdir -p "$CONTAINER_SESSION_DIR"
+
+  # Hard-link session files between directories (bidirectional).
+  sync_sessions() {
+    local src="$1" dst="$2"
+    for item in "$src"/*; do
+      [[ -e "$item" ]] || continue
+      local base
+      base=$(basename "$item")
+      local target="$dst/$base"
+      if [[ -f "$item" ]] && [[ ! -L "$item" ]]; then
+        if [[ ! -e "$target" ]]; then
+          ln "$item" "$target" 2>/dev/null || cp "$item" "$target"
+        fi
+      elif [[ -d "$item" ]] && [[ ! -L "$item" ]]; then
+        mkdir -p "$target"
+        sync_sessions "$item" "$target"
+      fi
+    done
+  }
+
+  if [[ "$HOST_ENCODED" != "$CONTAINER_ENCODED" ]]; then
+    sync_sessions "$HOST_SESSION_DIR" "$CONTAINER_SESSION_DIR"
+    sync_sessions "$CONTAINER_SESSION_DIR" "$HOST_SESSION_DIR"
+    echo "link-claude-config: ${CONTAINER_ENCODED} <-> ${HOST_ENCODED} (hard-linked)"
+  else
+    echo "link-claude-config: ${CONTAINER_ENCODED} (same encoding, no sync needed)"
+  fi
+
+  # --- 6. Prompt history (history.jsonl) ---
+  # Claude Code uses ~/.claude/history.jsonl for prompt search/autocomplete.
+  # The host's history.jsonl (on the staging mount) contains entries with host
+  # project paths. We extract entries matching this repo and append them to
+  # the container's history.jsonl with the project field rewritten.
+  HOST_HISTORY="${STAGING}/history.jsonl"
+  CONTAINER_HISTORY="${CLAUDE_DIR}/history.jsonl"
+
+  # Extract host entries for this repo, rewrite project path, and append new ones.
+  # Single Python script handles dedup and writing to avoid brittle shell→Python piping.
+  python3 -c "
+import json, sys
+
+container_path = '$CONTAINER_PATH'
+host_path = '$HOST_PATH'
+host_history = '$HOST_HISTORY'
+container_history = '$CONTAINER_HISTORY'
+
+# 1. Collect session IDs already in the container's history to avoid duplicates.
+existing = set()
+try:
+    with open(container_history) as f:
+        for line in f:
+            try:
+                entry = json.loads(line)
+                sid = entry.get('sessionId', '')
+                ts = entry.get('timestamp', 0)
+                if sid and ts:
+                    existing.add(f'{sid}:{ts}')
+            except json.JSONDecodeError:
+                pass
+except FileNotFoundError:
+    pass
+
+# 2. Find relevant entries in host history, rewrite project path, append if new.
+match_paths = {host_path}
+
+added = 0
+try:
+    with open(host_history) as src, open(container_history, 'a') as dst:
+        for line in src:
+            try:
+                entry = json.loads(line)
+                proj = entry.get('project', '')
+                if proj not in match_paths:
+                    continue
+                sid = entry.get('sessionId', '')
+                ts = entry.get('timestamp', 0)
+                key = f'{sid}:{ts}'
+                if key not in existing:
+                    existing.add(key)
+                    entry['project'] = container_path
+                    dst.write(json.dumps(entry, separators=(',', ':')) + '\n')
+                    added += 1
+            except json.JSONDecodeError:
+                pass
+    print(f'link-claude-config: history.jsonl += {added} entries from host')
+except FileNotFoundError:
+    print('link-claude-config: no host history.jsonl found, skipping index sync')
+except Exception as e:
+    print(f'link-claude-config: history.jsonl sync failed: {e}', file=sys.stderr)
+" 2>/dev/null || echo "link-claude-config: history.jsonl sync skipped (python3 unavailable)"
+
+fi

--- a/README.md
+++ b/README.md
@@ -57,4 +57,11 @@ and rule implementation guide.
 The fastest way to get a working dev environment is with a
 [Dev Container](.devcontainer/README.md) — open the repo in VS Code or Cursor and run
 **Dev Containers: Reopen in Container**. Everything (Node 22, pnpm, gh CLI, Graphite CLI,
-Claude Code) is pre-installed.
+Claude Code) is pre-installed, and host authentication (gh, gt, Claude) persists across rebuilds
+via bind mounts.
+
+For local AI code review before CI, install
+[PAL MCP Server](https://github.com/BeehiveInnovations/pal-mcp-server) on your host — the
+Dev Container picks up your MCP config automatically. PAL enables the `/review-pr` skill to run
+local code review (Phase 1) before pushing, catching issues without a full CI round-trip. See
+[setup details](.devcontainer/README.md#pal-mcp-server-recommended).


### PR DESCRIPTION
## Summary

- Bind-mount host `~/.claude`, `~/.claude.json`, `~/.config/gh`, and `~/.config/graphite` into
  the devcontainer so authentication persists across rebuilds
- Add `install-tools.sh` to replace the inline `postCreateCommand` with a structured script
  (pnpm, graphite, claude, uv/uvx for PAL)
- Add `link-claude-config.sh` to symlink credentials, MCP config, and settings to the host
  staging mount; hard-link session files for cross-environment `/resume`; merge host prompt history
- Add `fix-host-worktrees.sh` — optional host-side script that creates a symlink so worktrees
  created inside the container also work on the host
- Open the **main repo** in the devcontainer (not a worktree); the CLAUDE.md workflow creates
  worktrees inside `.worktrees/` which persist across rebuilds via the bind mount
- Document the mount table, `/resume` mechanics, and PAL MCP setup in `.devcontainer/README.md`
  and root `README.md`

## Test plan
- [x] `pnpm check` passes
- [x] Container builds successfully with host dirs present
- [ ] `gh auth status` works after rebuild (manual verification)
- [ ] Claude Code starts authenticated after rebuild (manual verification)
- [ ] `/resume` works bidirectionally between host and container (manual verification)
- [ ] PAL MCP tools available via `/mcp` (manual verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)