### PR TITLE
Closes #71: replace pre-push branch naming with post-checkout hook

### DIFF
--- a/.husky/post-checkout
+++ b/.husky/post-checkout
@@ -1,0 +1,26 @@
+#!/usr/bin/env sh
+# post-checkout fires after: git checkout -b, git switch -c, git checkout <branch>
+# $1 = previous HEAD, $2 = new HEAD, $3 = 1 (branch checkout) / 0 (file checkout)
+
+CHECKOUT_TYPE=$3
+[ "$CHECKOUT_TYPE" = "0" ] && exit 0  # file checkout — skip
+
+BRANCH=$(git symbolic-ref --short HEAD 2>/dev/null) || exit 0
+
+# Allow main (managed directly, not via Graphite)
+[ "$BRANCH" = "main" ] && exit 0
+
+PATTERN='^(feat|fix|chore|docs|refactor|test|ci)/sass-lint-[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$'
+
+if ! echo "$BRANCH" | grep -qE "$PATTERN"; then
+  echo "WARNING: Branch name '$BRANCH' does not follow convention."
+  echo ""
+  echo "  Required: <type>/sass-lint-<issue#>-<title>"
+  echo "  Example:  feat/sass-lint-12-no-debug"
+  echo ""
+  echo "  Valid types: feat, fix, chore, docs, refactor, test, ci"
+  echo "  Title must be kebab-case (lowercase letters, numbers, hyphens)"
+  echo ""
+  echo "  Rename with: git branch -m $BRANCH <correct-name>"
+fi
+# Note: post-checkout exit code is informational — git does not undo the checkout.

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,18 +1,2 @@
-branch=$(git symbolic-ref --short HEAD 2>/dev/null)
-
-# Allow main (pushed directly, not via Graphite)
-if [ "$branch" = "main" ]; then
-  exit 0
-fi
-
-# Enforce branch naming convention: <type>/sass-lint-<issue#>-<title>
-if ! echo "$branch" | grep -qE '^(feat|fix|chore|docs|refactor|test|ci)/sass-lint-[0-9]+-[a-z0-9]+(-[a-z0-9]+)*$'; then
-  echo "ERROR: Branch name '$branch' does not follow convention."
-  echo ""
-  echo "  Required: <type>/sass-lint-<issue#>-<title>"
-  echo "  Example:  feat/sass-lint-12-no-debug"
-  echo ""
-  echo "  Valid types: feat, fix, chore, docs, refactor, test, ci"
-  echo "  Title must be kebab-case (lowercase letters, numbers, hyphens)"
-  exit 1
-fi
+# Branch naming convention is enforced by .husky/post-checkout (fires immediately on checkout).
+# Add any pre-push checks here that are unrelated to branch naming.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,8 +26,10 @@ pnpm run format:check
 - Conventional commits: `feat(#N):`, `fix(#N):`, `chore(#N):`, `docs(#N):` — always reference
   the issue number
 - Branch naming: `<type>/sass-lint-<issue#>-<title>` (e.g. `feat/sass-lint-12-no-debug`).
-  Enforced by a `pre-push` hook (`.husky/pre-push`). Valid types: `feat`, `fix`, `chore`, `docs`,
-  `refactor`, `test`, `ci`. Title must be kebab-case. Every branch must reference an issue number.
+  Enforced by a `post-checkout` hook (`.husky/post-checkout`) — fires immediately on branch
+  creation so the agent can self-correct before doing any work. Valid types: `feat`, `fix`,
+  `chore`, `docs`, `refactor`, `test`, `ci`. Title must be kebab-case. Every branch must
+  reference an issue number.
 - TSDoc on all exported functions and constants — include `@param`, `@returns`, `@example`
 
 ## Workflow Rules


### PR DESCRIPTION
## Summary

- Adds `.husky/post-checkout` that validates branch naming convention immediately on branch creation, giving the agent real-time feedback before any work begins
- Removes branch naming check from `.husky/pre-push` (now a comment stub for future checks)
- Updates `CLAUDE.md` to reference the new enforcement hook timing and behavior

## Test plan

- [x] `.husky/post-checkout` warns and prints rename command for non-conforming branch names
- [x] `.husky/post-checkout` skips file checkouts (`$3 = 0`) and allows `main` branch
- [x] `.husky/pre-push` no longer blocks pushes based on branch naming
- [x] Hook fires on `git checkout -b`, `git switch -c`, and branch switching operations