### PR TITLE
Closes #70: flatten wiki rule specs to root (fix broken links)

### DIFF
--- a/.claude/skills/add-rule/SKILL.md
+++ b/.claude/skills/add-rule/SKILL.md
@@ -29,7 +29,7 @@ Implement the rule specified in `$ARGUMENTS`.
    WIKI=$(bash .claude/scripts/ensure-wiki.sh)
    ```
 
-   Read the spec from `$WIKI/rules/design/sass-<rule-name>.md`
+   Read the spec from `$WIKI/sass-<rule-name>.md`
 
 3. Write the test file **first** at
    `src/rules/<rule-name>/index.test.ts` using the BAD/GOOD

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -33,7 +33,7 @@ If the issue is about implementing a lint rule:
    WIKI=$(bash .claude/scripts/ensure-wiki.sh)
    ```
 
-   Load the spec from `$WIKI/rules/design/`.
+   Load the spec from `$WIKI/`.
    Match by rule name (e.g. issue title
    `sass/at-use-no-unnamespaced` →
    `sass-at-use-no-unnamespaced.md`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,14 +105,14 @@ same clone via absolute path.
 
 ### Key pages
 
-| Page                                | Content                                    |
-| ----------------------------------- | ------------------------------------------ |
-| `$WIKI/Architecture.md`             | Package structure, rule pattern, AST notes |
-| `$WIKI/Roadmap.md`                  | 8-phase roadmap with exit criteria         |
-| `$WIKI/Implementation-Plan.md`      | Detailed implementation plan               |
-| `$WIKI/Execution-Steps.md`          | Atomic execution steps                     |
-| `$WIKI/Desired-State.md`            | Config, CLI usage, recommended preset      |
-| `$WIKI/rules/design/sass-<name>.md` | Per-rule design specs (23 total)           |
+| Page                           | Content                                    |
+| ------------------------------ | ------------------------------------------ |
+| `$WIKI/Architecture.md`        | Package structure, rule pattern, AST notes |
+| `$WIKI/Roadmap.md`             | 8-phase roadmap with exit criteria         |
+| `$WIKI/Implementation-Plan.md` | Detailed implementation plan               |
+| `$WIKI/Execution-Steps.md`     | Atomic execution steps                     |
+| `$WIKI/Desired-State.md`       | Config, CLI usage, recommended preset      |
+| `$WIKI/sass-<name>.md`         | Per-rule design specs (23 total)           |
 
 ### Updating the wiki
 

--- a/docs/sdlc.md
+++ b/docs/sdlc.md
@@ -335,7 +335,7 @@ automates this process, but the steps are the same for manual work.
 
 Each rule has a design spec in the
 [wiki](https://github.com/theagenticengineer/stylelint-sass/wiki)
-(`rules/design/` directory) with:
+(named `sass-<rule-name>.md`) with:
 
 - Rule name and description
 - BAD examples (code that should trigger a warning)
@@ -425,14 +425,14 @@ pnpm check  # all gates must pass
 
 <!-- markdownlint-disable MD013 MD060 -->
 
-| Artifact            | Path                                                                                            |
-| ------------------- | ----------------------------------------------------------------------------------------------- |
-| Rule implementation | `src/rules/<name>/index.ts`                                                                     |
-| Rule tests          | `src/rules/<name>/index.test.ts`                                                                |
-| Rule documentation  | `docs/rules/<name>.md`                                                                          |
-| Plugin registration | `src/index.ts`                                                                                  |
-| Recommended default | `src/recommended.ts`                                                                            |
-| Rule spec (design)  | [Wiki](https://github.com/theagenticengineer/stylelint-sass/wiki) `rules/design/sass-<name>.md` |
+| Artifact            | Path                                                                               |
+| ------------------- | ---------------------------------------------------------------------------------- |
+| Rule implementation | `src/rules/<name>/index.ts`                                                        |
+| Rule tests          | `src/rules/<name>/index.test.ts`                                                   |
+| Rule documentation  | `docs/rules/<name>.md`                                                             |
+| Plugin registration | `src/index.ts`                                                                     |
+| Recommended default | `src/recommended.ts`                                                               |
+| Rule spec (design)  | [Wiki](https://github.com/theagenticengineer/stylelint-sass/wiki) `sass-<name>.md` |
 
 <!-- markdownlint-enable MD013 MD060 -->
 


### PR DESCRIPTION
## Summary

- Flatten wiki rule specs from `rules/design/` subdirectory to wiki root
- GitHub wiki converts `/` to `-` in URLs, breaking `[[rules/design/...]]` links
- Update all code repo path references from `$WIKI/rules/design/sass-<name>.md` to `$WIKI/sass-<name>.md`
- Files affected: CLAUDE.md, add-rule skill, review-pr skill, docs/sdlc.md

## Test plan

- [x] `pnpm check` passes (340 tests)
- [x] Wiki links verified working at https://github.com/theagenticengineer/stylelint-sass/wiki

🤖 Generated with [Claude Code](https://claude.com/claude-code)